### PR TITLE
If empty valued attributes are sent at user creation or update, we are n...

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon/core/encoder/json/JSONDecoder.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon/core/encoder/json/JSONDecoder.java
@@ -80,6 +80,10 @@ public class JSONDecoder implements Decoder {
                 Object attributeValObj = decodedJsonObj.opt(attributeSchema.getName());
 
                 if (attributeValObj instanceof String) {
+                    //If an attribute is passed without a value, no need to save it.
+                    if(((String) attributeValObj).isEmpty()){
+                        continue;
+                    }
                     //if the corresponding json value object is String, it is a SimpleAttribute.
                     scimObject.setAttribute(buildSimpleAttribute(attributeSchema, attributeValObj));
                     
@@ -242,6 +246,9 @@ public class JSONDecoder implements Decoder {
                 Object attributeValue = attributeValues.get(i);
 
                 if (attributeValue instanceof String) {
+                    if(((String) attributeValue).isEmpty()){
+                        continue;
+                    }
                     simpleAttributeValues.add((String) attributeValues.get(i));
                 } else if (attributeValue instanceof JSONObject) {
                     JSONObject complexAttributeValue = (JSONObject) attributeValue;
@@ -353,6 +360,9 @@ public class JSONDecoder implements Decoder {
 					attributesMap.put(subAttributeSchema.getName(), simpleAttribute);
 				}
 				if (subAttributeValue instanceof String) {
+                    if(((String) subAttributeValue).isEmpty()){
+                        continue;
+                    }
 					SimpleAttribute simpleAttribute =
 					                                  buildSimpleAttribute(subAttributeSchema,
 					                                                       subAttributeValue);
@@ -392,6 +402,9 @@ public class JSONDecoder implements Decoder {
 					attributesMap.put(simpleAttribute.getName(), simpleAttribute);
 				}
 				if (subAttributeValue instanceof String) {
+                    if(((String) subAttributeValue).isEmpty()){
+                        continue;
+                    }
 					SimpleAttribute simpleAttribute =
 					                                  buildSimpleAttribute(attribSchema, subAttributeValue);
 					attributesMap.put(simpleAttribute.getName(), simpleAttribute);

--- a/modules/charon-core/src/test/java/org/wso2/charon/core/decoder/JSONDecoderTest.java
+++ b/modules/charon-core/src/test/java/org/wso2/charon/core/decoder/JSONDecoderTest.java
@@ -120,7 +120,7 @@ public class JSONDecoderTest {
                                   "      \"type\": \"thumbnail\"\n" +
                                   "    }\n" +
                                   "  ],\n" +
-                                  "  \"userType\": \"Employee\",\n" +
+                                  "  \"userType\": \"\",\n" +
                                   "  \"title\": \"Tour Guide\",\n" +
                                   "  \"preferredLanguage\":\"en_US\",\n" +
                                   "  \"locale\": \"en_US\",\n" +
@@ -189,7 +189,7 @@ public class JSONDecoderTest {
             Assert.assertEquals("555-555-5555", decodedUser.getPhoneNumbers("work").get(0));
             Assert.assertEquals("555-555-4444", decodedUser.getPhoneNumbers("mobile").get(0));
             Assert.assertEquals("someaimhandle", decodedUser.getIMs("aim").get(0));
-            Assert.assertEquals("Employee", decodedUser.getUserType());
+            Assert.assertNull("Since the value of user type was empty, this should not be returned from storage",decodedUser.getUserType());
             Assert.assertEquals("Tour Guide", decodedUser.getTitle());
             Assert.assertEquals("en_US", decodedUser.getPreferredLanguage());
             Assert.assertEquals("en_US", decodedUser.getLocale());


### PR DESCRIPTION
...ot saving them to storage. Simply ignored if no value is set for the attribute