### PR TITLE
Fix IDENTITY-5083

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon/core/protocol/endpoints/AbstractResourceEndpoint.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon/core/protocol/endpoints/AbstractResourceEndpoint.java
@@ -17,28 +17,17 @@
 */
 package org.wso2.charon.core.protocol.endpoints;
 
+import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.wso2.charon.core.attributes.Attribute;
 import org.wso2.charon.core.encoder.Decoder;
 import org.wso2.charon.core.encoder.Encoder;
-import org.wso2.charon.core.encoder.json.JSONDecoder;
-import org.wso2.charon.core.encoder.json.JSONEncoder;
 import org.wso2.charon.core.exceptions.AbstractCharonException;
 import org.wso2.charon.core.exceptions.CharonException;
 import org.wso2.charon.core.exceptions.FormatNotSupportedException;
-import org.wso2.charon.core.exceptions.NotFoundException;
-import org.wso2.charon.core.objects.AbstractSCIMObject;
-import org.wso2.charon.core.objects.ListedResource;
-import org.wso2.charon.core.objects.SCIMObject;
-import org.wso2.charon.core.objects.User;
-import org.wso2.charon.core.protocol.ResponseCodeConstants;
 import org.wso2.charon.core.protocol.SCIMResponse;
 import org.wso2.charon.core.schema.SCIMConstants;
 
-import org.apache.commons.logging.Log;
-
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -101,7 +90,7 @@ public abstract class AbstractResourceEndpoint implements ResourceEndpoint {
             //log a warn message.
             String warnMessage = "Format cannot be null. Unable to register encoder for provided format.";
             log.warn(warnMessage);
-        }else if (encoderMap.containsKey(format)) {
+        } else if (encoderMap.containsKey(format)) {
             //log a warn message.
             String warnMessage = "Encoder for the given format is already registered.";
             log.warn(warnMessage);
@@ -123,7 +112,7 @@ public abstract class AbstractResourceEndpoint implements ResourceEndpoint {
             //log a warn message.
             String warnMessage = "Format cannot be null. Unable to register decoder for provided format.";
             log.warn(warnMessage);
-        }else if (decoderMap.containsKey(format)) {
+        } else if (decoderMap.containsKey(format)) {
             //log a warn message.
             String warnMessage = "Decoder for the given format is already registered.";
             log.warn(warnMessage);

--- a/modules/charon-core/src/main/java/org/wso2/charon/core/protocol/endpoints/AbstractResourceEndpoint.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon/core/protocol/endpoints/AbstractResourceEndpoint.java
@@ -70,7 +70,7 @@ public abstract class AbstractResourceEndpoint implements ResourceEndpoint {
     public Encoder getEncoder(String format)
             throws FormatNotSupportedException, CharonException {
         //if the requested format not supported, return an error.
-        if (!encoderMap.containsKey(format)) {
+        if (format == null || !encoderMap.containsKey(format)) {
             //Error is logged by the caller.
             throw new FormatNotSupportedException();
         }
@@ -81,7 +81,7 @@ public abstract class AbstractResourceEndpoint implements ResourceEndpoint {
             throws FormatNotSupportedException, CharonException {
 
         //if the requested format not supported, return an error.
-        if ((format == null) && (!decoderMap.containsKey(format))) {
+        if (format == null || !decoderMap.containsKey(format)) {
             //Error is logged by the caller.
             throw new FormatNotSupportedException();
         }
@@ -96,7 +96,12 @@ public abstract class AbstractResourceEndpoint implements ResourceEndpoint {
      * @param encoder
      */
     public static void registerEncoder(String format, Encoder encoder) throws CharonException {
-        if (encoderMap.containsKey(format)) {
+
+        if (format == null) {
+            //log a warn message.
+            String warnMessage = "Format cannot be null. Unable to register encoder for provided format.";
+            log.warn(warnMessage);
+        }else if (encoderMap.containsKey(format)) {
             //log a warn message.
             String warnMessage = "Encoder for the given format is already registered.";
             log.warn(warnMessage);
@@ -113,7 +118,12 @@ public abstract class AbstractResourceEndpoint implements ResourceEndpoint {
      * @throws CharonException
      */
     public static void registerDecoder(String format, Decoder decoder) throws CharonException {
-        if (decoderMap.containsKey(format)) {
+
+        if (format == null) {
+            //log a warn message.
+            String warnMessage = "Format cannot be null. Unable to register decoder for provided format.";
+            log.warn(warnMessage);
+        }else if (decoderMap.containsKey(format)) {
             //log a warn message.
             String warnMessage = "Decoder for the given format is already registered.";
             log.warn(warnMessage);

--- a/modules/charon-core/src/main/java/org/wso2/charon/core/protocol/endpoints/BulkResourceEndpoint.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon/core/protocol/endpoints/BulkResourceEndpoint.java
@@ -77,17 +77,14 @@ public class BulkResourceEndpoint extends AbstractResourceEndpoint implements Re
             //careate SCIM response message
             response.setResponseMessage(finalEncodedResponse);
         } catch (BadRequestException e) {
-            e.printStackTrace();
-            logger.error(e.getDescription());
+            logger.error(e.getDescription(), e);
             return AbstractResourceEndpoint.encodeSCIMException(encoder, e);
         } catch (FormatNotSupportedException e) {
-            e.printStackTrace();
-            logger.error(e.getDescription());
+            logger.error(e.getDescription(), e);
             //if requested format not supported, encode exception and set it in the response.
             return AbstractResourceEndpoint.encodeSCIMException(encoder, e);
         } catch (CharonException e) {
-            e.printStackTrace();
-            logger.error(e.getDescription());
+            logger.error(e.getDescription(), e);
             //we have charon exceptions also, instead of having only internal server error exceptions,
             //because inside API code throws CharonException.
             if (e.getCode() == -1) {


### PR DESCRIPTION
Adding null checks to prevent null key addition to concurrent hash maps holding encoders and decoders .