### PR TITLE
IDENTITY-6965: Intermitent issue in SCIM group creation

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/Group.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/Group.java
@@ -28,6 +28,7 @@ import org.wso2.charon3.core.schema.SCIMResourceTypeSchema;
 import org.wso2.charon3.core.schema.SCIMSchemaDefinitions;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -83,8 +84,11 @@ public class Group extends AbstractSCIMObject {
             for (Attribute subValue : subValuesList) {
                 ComplexAttribute complexAttribute = (ComplexAttribute) subValue;
                 Map<String, Attribute> subAttributesList = complexAttribute.getSubAttributesList();
-                memberList.add(((SimpleAttribute) (subAttributesList.get(
-                                SCIMConstants.CommonSchemaConstants.VALUE))).getValue());
+                if(subAttributesList != null|| subAttributesList.containsKey(
+                        SCIMConstants.CommonSchemaConstants.VALUE)) {
+                    memberList.add(((SimpleAttribute) (subAttributesList.get(
+                            SCIMConstants.CommonSchemaConstants.VALUE))).getValue());
+                }
             }
             return memberList;
         } else {
@@ -107,8 +111,12 @@ public class Group extends AbstractSCIMObject {
                 for (Attribute subValue : subValuesList) {
                     ComplexAttribute complexAttribute = (ComplexAttribute) subValue;
                     Map<String, Attribute> subAttributesList = complexAttribute.getSubAttributesList();
-                    displayNames.add(((SimpleAttribute) (subAttributesList.get(
-                            SCIMConstants.CommonSchemaConstants.DISPLAY))).getValue());
+                    if(subAttributesList != null|| subAttributesList.containsKey(
+                            SCIMConstants.CommonSchemaConstants.DISPLAY)) {
+                        displayNames.add(((SimpleAttribute) (subAttributesList.get(
+                                SCIMConstants.CommonSchemaConstants.DISPLAY))).getValue());
+                    }
+
                 }
                 return displayNames;
             }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/Group.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/Group.java
@@ -84,7 +84,7 @@ public class Group extends AbstractSCIMObject {
             for (Attribute subValue : subValuesList) {
                 ComplexAttribute complexAttribute = (ComplexAttribute) subValue;
                 Map<String, Attribute> subAttributesList = complexAttribute.getSubAttributesList();
-                if(subAttributesList != null|| subAttributesList.containsKey(
+                if(subAttributesList != null && subAttributesList.containsKey(
                         SCIMConstants.CommonSchemaConstants.VALUE)) {
                     memberList.add(((SimpleAttribute) (subAttributesList.get(
                             SCIMConstants.CommonSchemaConstants.VALUE))).getValue());
@@ -111,7 +111,7 @@ public class Group extends AbstractSCIMObject {
                 for (Attribute subValue : subValuesList) {
                     ComplexAttribute complexAttribute = (ComplexAttribute) subValue;
                     Map<String, Attribute> subAttributesList = complexAttribute.getSubAttributesList();
-                    if(subAttributesList != null|| subAttributesList.containsKey(
+                    if(subAttributesList != null && subAttributesList.containsKey(
                             SCIMConstants.CommonSchemaConstants.DISPLAY)) {
                         displayNames.add(((SimpleAttribute) (subAttributesList.get(
                                 SCIMConstants.CommonSchemaConstants.DISPLAY))).getValue());

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/Group.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/Group.java
@@ -28,7 +28,6 @@ import org.wso2.charon3.core.schema.SCIMResourceTypeSchema;
 import org.wso2.charon3.core.schema.SCIMSchemaDefinitions;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -84,7 +83,7 @@ public class Group extends AbstractSCIMObject {
             for (Attribute subValue : subValuesList) {
                 ComplexAttribute complexAttribute = (ComplexAttribute) subValue;
                 Map<String, Attribute> subAttributesList = complexAttribute.getSubAttributesList();
-                if(subAttributesList != null && subAttributesList.containsKey(
+                if (subAttributesList != null && subAttributesList.containsKey(
                         SCIMConstants.CommonSchemaConstants.VALUE)) {
                     memberList.add(((SimpleAttribute) (subAttributesList.get(
                             SCIMConstants.CommonSchemaConstants.VALUE))).getValue());
@@ -111,7 +110,7 @@ public class Group extends AbstractSCIMObject {
                 for (Attribute subValue : subValuesList) {
                     ComplexAttribute complexAttribute = (ComplexAttribute) subValue;
                     Map<String, Attribute> subAttributesList = complexAttribute.getSubAttributesList();
-                    if(subAttributesList != null && subAttributesList.containsKey(
+                    if (subAttributesList != null && subAttributesList.containsKey(
                             SCIMConstants.CommonSchemaConstants.DISPLAY)) {
                         displayNames.add(((SimpleAttribute) (subAttributesList.get(
                                 SCIMConstants.CommonSchemaConstants.DISPLAY))).getValue());


### PR DESCRIPTION
## Purpose
> Fix Intermittent issue in SCIM group creation

## Goals
> Fix Intermittent issue in SCIM group creation

## Approach
> When the groups creation request sent with members attribute and not having any attributes in the members array, this will ignore the empty array and create the group.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
> N/A

## Security checks
> N/A

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A