### PR TITLE
ServiceProviderConfig:authenticationSchemes.specUri should match SCIM 2.0

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMConstants.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMConstants.java
@@ -513,9 +513,9 @@ public class SCIMConstants {
         public static final String DESCRIPTION = "description";
         public static final String DESCRIPTION_URI =
                 "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig:authenticationSchemes.description";
-        public static final String SPEC_URI = "specURI";
+        public static final String SPEC_URI = "specUri";
         public static final String SPEC_URI_URI =
-                "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig:authenticationSchemes.specURI";
+                "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig:authenticationSchemes.specUri";
         public static final String TYPE = "type";
         public static final String TYPE_URL =
                 "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig:authenticationSchemes.type";

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMSchemaDefinitions.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMSchemaDefinitions.java
@@ -995,7 +995,7 @@ public class SCIMSchemaDefinitions {
                         SCIMConstants.ServiceProviderConfigSchemaConstants.SPEC_URI_URI,
                         SCIMConstants.ServiceProviderConfigSchemaConstants.SPEC_URI,
                         SCIMDefinitions.DataType.REFERENCE, false,
-                        SCIMConstants.ServiceProviderConfigSchemaConstants.SPEC_URI_DESC, true, false,
+                        SCIMConstants.ServiceProviderConfigSchemaConstants.SPEC_URI_DESC, false, false,
                         SCIMDefinitions.Mutability.READ_ONLY, SCIMDefinitions.Returned.DEFAULT,
                         SCIMDefinitions.Uniqueness.NONE, null,
                         new ArrayList<SCIMDefinitions.ReferenceType>(Arrays.asList(SCIMDefinitions.ReferenceType
@@ -1007,7 +1007,7 @@ public class SCIMSchemaDefinitions {
                         SCIMConstants.ServiceProviderConfigSchemaConstants.DOCUMENTATION_URI,
                         SCIMConstants.ServiceProviderConfigSchemaConstants.AUTHENTICATION_SCHEMAS_DOCUMENTATION_URI_URI,
                         SCIMDefinitions.DataType.REFERENCE, false,
-                        SCIMConstants.ServiceProviderConfigSchemaConstants.DOCUMENTATION_URI_DESC, true, false,
+                        SCIMConstants.ServiceProviderConfigSchemaConstants.DOCUMENTATION_URI_DESC, false, false,
                         SCIMDefinitions.Mutability.READ_ONLY, SCIMDefinitions.Returned.DEFAULT,
                         SCIMDefinitions.Uniqueness.NONE, null,
                         new ArrayList<SCIMDefinitions.ReferenceType>(Arrays.asList(SCIMDefinitions.ReferenceType
@@ -1029,7 +1029,7 @@ public class SCIMSchemaDefinitions {
                         SCIMConstants.ServiceProviderConfigSchemaConstants.PRIMARY,
                         SCIMDefinitions.DataType.BOOLEAN, false, SCIMConstants.ServiceProviderConfigSchemaConstants
                                 .PRIMARY_DESC,
-                        true, false, SCIMDefinitions.Mutability.READ_ONLY, SCIMDefinitions.Returned.DEFAULT,
+                        false, false, SCIMDefinitions.Mutability.READ_ONLY, SCIMDefinitions.Returned.DEFAULT,
                         SCIMDefinitions.Uniqueness.NONE, null, null, null);
 
     /*------------------------------------------------------------------------------------------------------*/


### PR DESCRIPTION
spec RFC7643

authenticationSchemes.documentationUri is also NOT required.
Fix for:
- https://github.com/wso2-incubator/scim2-compliance-test-suite/issues/11
- https://github.com/wso2/charon/issues/93

## Purpose
https://github.com/wso2/charon/issues/93

## Goals

## Approach

## User stories

## Release note
Schema definitions for authenticationSchems.specUri and authenticationSchemes.documentatinUri within /ServiceProviderConfig should match the SCIM 2.0 RFC7643

## Documentation

## Training

## Certification

## Marketing

## Automation tests
NA

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
This is a screenshot of the response used for testing:
![serviceproviderconfig](https://user-images.githubusercontent.com/1435496/37069832-5adce43e-2172-11e8-9d05-44b71b4d629b.png)

## Related PRs

## Migrations (if applicable)

## Test environment
JDK 8
 