### PR TITLE
Fix inability to list multi-valued attributes via SCIM2 filter operation

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/AttributeUtil.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/AttributeUtil.java
@@ -189,6 +189,20 @@ public class AttributeUtil {
             if (subAttributeURI != null) {
                 return subAttributeURI;
             }
+
+            if (attributeName.contains(attributeSchema.getName()) && attributeSchema.getMultiValued()) {
+
+                String subAttribute = null;
+                if (attributeName.contains(".")) {
+                    String[] splittedString = attributeName.split("\\.", 2);
+                    subAttribute = splittedString[1];
+                }
+                subAttributeURI = attributeSchema.getURI();
+                if (subAttribute != null) {
+                    subAttributeURI = subAttributeURI + "." + subAttribute;
+                    return subAttributeURI;
+                }
+            }
         }
         String error = "Not a valid attribute name/uri";
         throw new BadRequestException(error, ResponseCodeConstants.INVALID_VALUE);


### PR DESCRIPTION
Currently in charon3, for multivalued attributes , it is designed to filter based on the defined sub-attributes only. E.g. for emails the defined sub-attributes would be type,value,primary,display. And the attribute URI is constructed as urn:ietf:params:scim:schemas:core:2.0:User:emails.{sub-attribute} . However we store the multi-valued attributes based on their actual SCIM URI in the underlying user-store. For Home Email SCIM URI is urn:ietf:params:scim:schemas:core:2.0:User:emails.home. Therefore, we need to construct the actual URIs of multi-valued attributes from the AttributeUtil similar to [1] in order to filter results based on them. 
Fixes https://github.com/wso2/product-is/issues/3073

[1] https://github.com/wso2/charon/blob/2.x.x/modules/charon-core/src/main/java/org/wso2/charon/core/util/AttributeUtil.java#L157