### PR TITLE
Fix inability to filter based on numeric values in SCIM2

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/codeutils/FilterTreeManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/codeutils/FilterTreeManager.java
@@ -51,6 +51,7 @@ public class FilterTreeManager {
         // Default settings in StreamTokenizer syntax initializer.
         input.wordChars('a', 'z');
         input.wordChars('A', 'Z');
+        // Specifies that all extended ASCII characters defined in HTML 4 standard, are word constituents.
         input.wordChars(128 + 32, 255);
         input.whitespaceChars(0, ' ');
         input.commentChar('/');
@@ -65,6 +66,7 @@ public class FilterTreeManager {
         input.wordChars('-', '-');
         input.wordChars('+', '+');
         input.wordChars('.', '.');
+        input.wordChars('*', '*');
 
         tokenList = new ArrayList<String>();
         String concatenatedString = "";

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/codeutils/FilterTreeManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/codeutils/FilterTreeManager.java
@@ -47,11 +47,25 @@ public class FilterTreeManager {
     public FilterTreeManager(String filterString, SCIMResourceTypeSchema schema) throws IOException {
         this.schema = schema;
         input = new StreamTokenizer(new StringReader(filterString));
+        input.resetSyntax();
+        // Default settings in StreamTokenizer syntax initializer.
+        input.wordChars('a', 'z');
+        input.wordChars('A', 'Z');
+        input.wordChars(128 + 32, 255);
+        input.whitespaceChars(0, ' ');
+        input.commentChar('/');
+        input.quoteChar('"');
+        input.quoteChar('\'');
+
         //Adding other string possible values
-        //TODO:is ths all?
         input.wordChars('@', '@');
         input.wordChars(':', ':');
         input.wordChars('_', '_');
+        input.wordChars('0', '9');
+        input.wordChars('-', '-');
+        input.wordChars('+', '+');
+        input.wordChars('.', '.');
+
         tokenList = new ArrayList<String>();
         String concatenatedString = "";
 


### PR DESCRIPTION
The streamTokenizer in FilterTreeManager is configured to detect only token type words [1]. Since numeric values are not handled here when querying on attributes with numeric values will give the following error.
{"schemas":"urn:ietf:params:scim:api:messages:2.0:Error","scimType":"InvalidFilter","detail":"Given filter operator is not supported.","status":"400"}

If we configure streamTokenizer to identify token type numeric (StreamTokenizer.TT_NUMBER), this will produce the number as a double precision floating point number and it treats the token as a number rather than a word, by setting the {@code ttype} field to the value {@code TT_NUMBER} and putting the numeric value of the token into the {@code nval} field.
 E.g. for filter value 123456, the input.nval will be 123456.0

Therefore as a solution to this, we can reset the tokenizer syntax table and initialize it to recognize numbers as words before parsing. Then, when encountering an attribute with numeric values e.g. phone number, date etc. those will be treated as tokens of type StreamTokenizer.TT_WORD. 

Fixes https://github.com/wso2/product-is/issues/3075

[1] https://github.com/wso2/charon/blob/master/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/codeutils/FilterTreeManager.java#L68