### PR TITLE
Add support to assign primitive values to multi-valued attributes

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONDecoder.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONDecoder.java
@@ -209,6 +209,7 @@ public class JSONDecoder {
             MultiValuedAttribute multiValuedAttribute = new MultiValuedAttribute(attributeSchema.getName());
 
             List<Attribute> complexAttributeValues = new ArrayList<Attribute>();
+            List<Object> simpleAttributeValues = new ArrayList<>();
 
             //iterate through JSONArray and create the list of string values.
             for (int i = 0; i < attributeValues.length(); i++) {
@@ -216,6 +217,16 @@ public class JSONDecoder {
                 if (attributeValue instanceof JSONObject) {
                     JSONObject complexAttributeValue = (JSONObject) attributeValue;
                     complexAttributeValues.add(buildComplexValue(attributeSchema, complexAttributeValue));
+                } else if (attributeValue instanceof String || attributeValue instanceof Integer || attributeValue
+                        instanceof Double || attributeValue instanceof Boolean || attributeValue == null) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Primitive attribute type detected. Attribute value: " + attributeValue);
+                    }
+                    // If an attribute is passed without a value, no need to save it.
+                    if (attributeValue == null) {
+                        continue;
+                    }
+                    simpleAttributeValues.add(attributeValue);
                 } else {
                     String error = "Unknown JSON representation for the MultiValued attribute " +
                             attributeSchema.getName() + " which has data type as " + attributeSchema.getType();
@@ -224,6 +235,7 @@ public class JSONDecoder {
 
             }
             multiValuedAttribute.setAttributeValues(complexAttributeValues);
+            multiValuedAttribute.setAttributePrimitiveValues(simpleAttributeValues);
 
             return (MultiValuedAttribute) DefaultAttributeFactory.createAttribute(attributeSchema,
                     multiValuedAttribute);

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONDecoder.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONDecoder.java
@@ -220,7 +220,13 @@ public class JSONDecoder {
                 } else if (attributeValue instanceof String || attributeValue instanceof Integer || attributeValue
                         instanceof Double || attributeValue instanceof Boolean || attributeValue == null) {
                     if (logger.isDebugEnabled()) {
-                        logger.debug("Primitive attribute type detected. Attribute value: " + attributeValue);
+                        if (attributeValue != null) {
+                            logger.debug(
+                                    "Primitive attribute type detected. Attribute type: " + attributeValue.getClass()
+                                            .getName() + ", attribute value: " + attributeValue);
+                        } else {
+                            logger.debug("Attribute value is null.");
+                        }
                     }
                     // If an attribute is passed without a value, no need to save it.
                     if (attributeValue == null) {


### PR DESCRIPTION
As per section 2.4 of SCIM2 core specification [1] the following can be noted.

> 
>     Multi-valued attributes contain a list of elements using the JSON
>     array format defined in Section 5 of [RFC7159]. Elements can be
>     either of the following:
> 
>     o primitive values, or
> 
>     o objects with a set of sub-attributes and values, using the JSON
>     object format defined in Section 4 of [RFC7159], in which case
>     they SHALL be considered to be complex attributes.

With current charon3 implementation, creating a user with a multi-valued attribute of primitive types gives an error.

Fixes https://github.com/wso2/product-is/issues/3078