### PR TITLE
fix charon 2.0.5 JSONDecoder doesn't decode boolean sub-attributes

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/AttributeUtil.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/AttributeUtil.java
@@ -50,16 +50,16 @@ public class AttributeUtil {
             return attributeValue;
         }
         String attributeStringValue = null;
-        if (!(attributeValue instanceof Boolean)) {
-            if (attributeValue instanceof Integer) {
-                attributeStringValue = String.valueOf(attributeValue);
-            } else if (attributeValue instanceof Double) {
-                attributeStringValue = String.valueOf(attributeValue);
-            } else if (JSONObject.NULL.equals(attributeValue)) {
-                attributeStringValue = "";
-            } else {
-                attributeStringValue = (String) attributeValue;
-            }
+        if (attributeValue instanceof Boolean) {
+        	attributeStringValue = String.valueOf(attributeValue);
+        } else if (attributeValue instanceof Integer) {
+            attributeStringValue = String.valueOf(attributeValue);
+        } else if (attributeValue instanceof Double) {
+            attributeStringValue = String.valueOf(attributeValue);
+        } else if (JSONObject.NULL.equals(attributeValue)) {
+            attributeStringValue = "";
+        } else {
+            attributeStringValue = (String) attributeValue;
         }
 
         switch (dataType) {

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/AttributeUtil.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/AttributeUtil.java
@@ -51,7 +51,7 @@ public class AttributeUtil {
         }
         String attributeStringValue = null;
         if (attributeValue instanceof Boolean) {
-        	attributeStringValue = String.valueOf(attributeValue);
+            attributeStringValue = String.valueOf(attributeValue);
         } else if (attributeValue instanceof Integer) {
             attributeStringValue = String.valueOf(attributeValue);
         } else if (attributeValue instanceof Double) {


### PR DESCRIPTION
## Purpose
Fix charon 2.0.5 JSONDecoder doesn't decode boolean sub-attributes #71
We hit this problem when syncing with Azure Active Directory
I don't know why the boolean value is handled differently. So this fix might not be correct and another approach might be required.

## Goals
Properly handle boolean values preventing NPE
