### PR TITLE
Fix possible nullpointer in Group- and UserResourceManager

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
@@ -43,6 +43,7 @@ import org.wso2.charon3.core.utils.codeutils.PatchOperation;
 import org.wso2.charon3.core.utils.codeutils.SearchRequest;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -278,8 +279,17 @@ public class GroupResourceManager extends AbstractResourceManager {
                 List<Object> tempList = userManager.listGroupsWithGET(rootNode, startIndex, count,
                         sortBy, sortOrder, requiredAttributes);
 
-                totalResults = (int) tempList.get(0);
-                tempList.remove(0);
+                if (tempList == null) {
+                    tempList = Collections.emptyList();
+                }
+
+                try {
+                    // left for backwards compatability
+                    totalResults = (int) tempList.get(0);
+                    tempList.remove(0);
+                } catch (IndexOutOfBoundsException | ClassCastException ex) {
+                    totalResults = tempList.size();
+                }
                 returnedGroups = tempList;
 
                 for (Object group : returnedGroups) {

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
@@ -284,7 +284,6 @@ public class GroupResourceManager extends AbstractResourceManager {
                 }
 
                 try {
-                    // left for backwards compatability
                     totalResults = (int) tempList.get(0);
                     tempList.remove(0);
                 } catch (IndexOutOfBoundsException | ClassCastException ex) {

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/UserResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/UserResourceManager.java
@@ -305,7 +305,6 @@ public class UserResourceManager extends AbstractResourceManager {
                 }
 
                 try {
-                    // left for backwards compatability
                     totalResults = (int) tempList.get(0);
                     tempList.remove(0);
                 } catch (IndexOutOfBoundsException | ClassCastException ex) {

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/UserResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/UserResourceManager.java
@@ -46,6 +46,7 @@ import org.wso2.charon3.core.utils.codeutils.PatchOperation;
 import org.wso2.charon3.core.utils.codeutils.SearchRequest;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -299,8 +300,18 @@ public class UserResourceManager extends AbstractResourceManager {
                 List<Object> tempList = userManager.listUsersWithGET(rootNode, startIndex, count,
                         sortBy, sortOrder, requiredAttributes);
 
-                totalResults = (int) tempList.get(0);
-                tempList.remove(0);
+                if (tempList == null) {
+                    tempList = Collections.emptyList();
+                }
+
+                try {
+                    // left for backwards compatability
+                    totalResults = (int) tempList.get(0);
+                    tempList.remove(0);
+                } catch (IndexOutOfBoundsException | ClassCastException ex) {
+                    totalResults = tempList.size();
+                }
+
                 returnedUsers = tempList;
 
                 for (Object user : returnedUsers) {


### PR DESCRIPTION
I found a bug in the Group- and UserResourceManager. In case that null is returned charon caused a NullPointerException. 

the fix will also add a new change that prevents that the developer must add the "totalResults" value in the returned list. But backward compatability for those who already did is preserved