### PR TITLE
Add attributes 'ref' and 'type' for group members

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/Group.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/Group.java
@@ -126,24 +126,33 @@ public class Group extends AbstractSCIMObject {
 
     /*
      * set a member to the group
-     * @param userId
-     * @param userName
+     * @param value
+     * @param display
      * @throws BadRequestException
      * @throws CharonException
      */
-    public void setMember(String userId, String userName) throws BadRequestException, CharonException {
-        if (this.isAttributeExist(SCIMConstants.GroupSchemaConstants.MEMBERS)) {
-            MultiValuedAttribute members = (MultiValuedAttribute) this.attributeList.get(
-                    SCIMConstants.GroupSchemaConstants.MEMBERS);
-            ComplexAttribute complexAttribute = setMemberCommon(userId, userName);
-            members.setAttributeValue(complexAttribute);
-        } else {
-            MultiValuedAttribute members = new MultiValuedAttribute(SCIMConstants.GroupSchemaConstants.MEMBERS);
-            DefaultAttributeFactory.createAttribute(SCIMSchemaDefinitions.SCIMGroupSchemaDefinition.MEMBERS, members);
-            ComplexAttribute complexAttribute = setMemberCommon(userId, userName);
-            members.setAttributeValue(complexAttribute);
-            this.setAttribute(members);
+    public void setMember(String value, String display) throws BadRequestException, CharonException {
+        setMember(value, display, null, null);
+    }
+
+    /*
+     * set a member to the group
+     * @param value
+     * @param display
+     * @param ref
+     * @param type
+     * @throws BadRequestException
+     * @throws CharonException
+     */
+    public void setMember(String value, String display, String ref, String type) throws BadRequestException, CharonException {
+        if (!this.isAttributeExist(SCIMConstants.GroupSchemaConstants.MEMBERS)) {
+          MultiValuedAttribute members = new MultiValuedAttribute(SCIMConstants.GroupSchemaConstants.MEMBERS);
+          DefaultAttributeFactory.createAttribute(SCIMSchemaDefinitions.SCIMGroupSchemaDefinition.MEMBERS, members);
+          this.setAttribute(members);
         }
+        MultiValuedAttribute members = (MultiValuedAttribute) this.getAttribute(SCIMConstants.GroupSchemaConstants.MEMBERS);
+        ComplexAttribute complexAttribute = setMemberCommon(value, display, ref, type);
+        members.setAttributeValue(complexAttribute);
     }
 
     /*
@@ -154,7 +163,7 @@ public class Group extends AbstractSCIMObject {
      * @throws BadRequestException
      * @throws CharonException
      */
-    private ComplexAttribute setMemberCommon(String userId, String userName)
+    private ComplexAttribute setMemberCommon(String userId, String userName, String ref, String type)
             throws BadRequestException, CharonException {
         ComplexAttribute complexAttribute = new ComplexAttribute();
         complexAttribute.setName(SCIMConstants.GroupSchemaConstants.MEMBERS + "_" + userId + SCIMConstants.DEFAULT);
@@ -167,8 +176,20 @@ public class Group extends AbstractSCIMObject {
         DefaultAttributeFactory.createAttribute(
                 SCIMSchemaDefinitions.SCIMGroupSchemaDefinition.DISPLAY, displaySimpleAttribute);
 
+        SimpleAttribute refSimpleAttribute = new SimpleAttribute(
+                SCIMConstants.CommonSchemaConstants.REF, ref);
+        DefaultAttributeFactory.createAttribute(
+                SCIMSchemaDefinitions.SCIMGroupSchemaDefinition.REF, refSimpleAttribute);
+
+        SimpleAttribute typeSimpleAttribute = new SimpleAttribute(
+                SCIMConstants.CommonSchemaConstants.TYPE, type);
+                DefaultAttributeFactory.createAttribute(
+                SCIMSchemaDefinitions.SCIMGroupSchemaDefinition.TYPE, typeSimpleAttribute);
+
         complexAttribute.setSubAttribute(valueSimpleAttribute);
         complexAttribute.setSubAttribute(displaySimpleAttribute);
+        complexAttribute.setSubAttribute(refSimpleAttribute);
+        complexAttribute.setSubAttribute(typeSimpleAttribute);
         DefaultAttributeFactory.createAttribute(
                 SCIMSchemaDefinitions.SCIMGroupSchemaDefinition.MEMBERS, complexAttribute);
         return  complexAttribute;

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/Group.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/Group.java
@@ -144,13 +144,14 @@ public class Group extends AbstractSCIMObject {
      * @throws BadRequestException
      * @throws CharonException
      */
-    public void setMember(String value, String display, String ref, String type) throws BadRequestException, CharonException {
-        if (!this.isAttributeExist(SCIMConstants.GroupSchemaConstants.MEMBERS)) {
+    public void setMember(String value, String display, String ref, String type) 
+           throws BadRequestException, CharonException {
+        if (!isAttributeExist(SCIMConstants.GroupSchemaConstants.MEMBERS)) {
           MultiValuedAttribute members = new MultiValuedAttribute(SCIMConstants.GroupSchemaConstants.MEMBERS);
           DefaultAttributeFactory.createAttribute(SCIMSchemaDefinitions.SCIMGroupSchemaDefinition.MEMBERS, members);
-          this.setAttribute(members);
+          setAttribute(members);
         }
-        MultiValuedAttribute members = (MultiValuedAttribute) this.getAttribute(SCIMConstants.GroupSchemaConstants.MEMBERS);
+        MultiValuedAttribute members = (MultiValuedAttribute) getAttribute(SCIMConstants.GroupSchemaConstants.MEMBERS);
         ComplexAttribute complexAttribute = setMemberCommon(value, display, ref, type);
         members.setAttributeValue(complexAttribute);
     }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMConstants.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMConstants.java
@@ -457,6 +457,7 @@ public class SCIMConstants {
         public static final String MEMBERS = "members";
         public static final String MEMBERS_URI = "urn:ietf:params:scim:schemas:core:2.0:User:members";
         public static final String DISPLAY = "display";
+        public static final String TYPE = "type";
 
         /*******Attributes descriptions of the attributes found in Group Schema.***************/
 
@@ -466,11 +467,13 @@ public class SCIMConstants {
         public static final String REF_DESC = "The uri corresponding to a SCIM resource that is a member of this " +
                 "Group.";
         public static final String DISPLAY_DESC = "A human-readable name for the Member";
+        public static final String TYPE_DESC = "A label indicating the type of resource, e.g. 'User' or 'Group'";
 
         /*******URIs of sub and multivalued attributes.**************/
         public static final String VALUE_URI = "urn:ietf:params:scim:schemas:core:2.0:Group:members.value";
         public static final String REF_URI = "urn:ietf:params:scim:schemas:core:2.0:Group:members.$ref";
         public static final String DISPLAY_URI = "urn:ietf:params:scim:schemas:core:2.0:Group:members.display";
+        public static final String TYPE_URI = "urn:ietf:params:scim:schemas:core:2.0:Group:members.type";
     }
 
     /**

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMSchemaDefinitions.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMSchemaDefinitions.java
@@ -857,6 +857,15 @@ public class SCIMSchemaDefinitions {
                         SCIMDefinitions.Mutability.READ_WRITE, SCIMDefinitions.Returned.DEFAULT,
                         SCIMDefinitions.Uniqueness.NONE, null, null, null);
 
+        //A label indicating the type of resource, e.g. 'User' or 'Group'.
+        public static final SCIMAttributeSchema TYPE =
+                SCIMAttributeSchema.createSCIMAttributeSchema(SCIMConstants.GroupSchemaConstants.TYPE_URI,
+                        SCIMConstants.GroupSchemaConstants.TYPE,
+                        SCIMDefinitions.DataType.STRING, false, SCIMConstants.GroupSchemaConstants.TYPE_DESC,
+                        false, false,
+                        SCIMDefinitions.Mutability.READ_WRITE, SCIMDefinitions.Returned.DEFAULT,
+                        SCIMDefinitions.Uniqueness.NONE, null, null, null);
+
     /*------------------------------------------------------------------------------------------------------*/
 
                 /* attribute schemas of the attributes defined in group schema. */
@@ -878,7 +887,7 @@ public class SCIMSchemaDefinitions {
                         false, false,
                         SCIMDefinitions.Mutability.READ_WRITE, SCIMDefinitions.Returned.DEFAULT,
                         SCIMDefinitions.Uniqueness.NONE, null, null, new ArrayList<SCIMAttributeSchema>(Arrays.asList
-                                (VALUE, REF, DISPLAY)));
+                                (VALUE, REF, DISPLAY, TYPE)));
     }
 
     /**


### PR DESCRIPTION
## Purpose
According to SCIM specification the members of a group
may have the attributes 'value', 'ref' and 'type'.

Resolves https://github.com/wso2/charon/issues/70

## Goals
Extended the schema definition to support the attributes. Added a setter to set the attributes on a group.
