### PR TITLE
Refactor interface AttributeSchema

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/config/SCIMUserSchemaExtensionBuilder.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/config/SCIMUserSchemaExtensionBuilder.java
@@ -20,6 +20,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.wso2.charon3.core.exceptions.CharonException;
 import org.wso2.charon3.core.exceptions.InternalErrorException;
+import org.wso2.charon3.core.schema.AttributeSchema;
 import org.wso2.charon3.core.schema.SCIMAttributeSchema;
 import org.wso2.charon3.core.schema.SCIMDefinitions;
 
@@ -45,15 +46,15 @@ public class SCIMUserSchemaExtensionBuilder {
     // extension root attribute name
     String extensionRootAttributeName = null;
     // built schema map
-    private static Map<String, SCIMAttributeSchema> attributeSchemas = new HashMap<String, SCIMAttributeSchema>();
+    private static Map<String, AttributeSchema> attributeSchemas = new HashMap<String, AttributeSchema>();
     // extension root attribute schema
-    private SCIMAttributeSchema extensionSchema = null;
+    private AttributeSchema extensionSchema = null;
 
     public static SCIMUserSchemaExtensionBuilder getInstance() {
         return configReader;
     }
 
-    public SCIMAttributeSchema getExtensionSchema() {
+    public AttributeSchema getExtensionSchema() {
         return extensionSchema;
     }
 
@@ -164,11 +165,11 @@ public class SCIMUserSchemaExtensionBuilder {
      */
     private void buildComplexSchema(ExtensionAttributeSchemaConfig config) {
         String[] subAttributeNames = config.getSubAttributes();
-        ArrayList<SCIMAttributeSchema> subAttributes = new ArrayList<SCIMAttributeSchema>();
+        ArrayList<AttributeSchema> subAttributes = new ArrayList<AttributeSchema>();
         for (String subAttributeName : subAttributeNames) {
             subAttributes.add(attributeSchemas.get(subAttributeName));
         }
-        SCIMAttributeSchema complexAttribute =
+        AttributeSchema complexAttribute =
                 createSCIMAttributeSchema(config, subAttributes);
         attributeSchemas.put(config.getName(), complexAttribute);
     }
@@ -179,9 +180,9 @@ public class SCIMUserSchemaExtensionBuilder {
      * @param config
      */
     private void buildSimpleAttributeSchema(ExtensionAttributeSchemaConfig config) {
-        ArrayList<SCIMAttributeSchema> subAttributeList = new ArrayList<SCIMAttributeSchema>();
+        ArrayList<AttributeSchema> subAttributeList = new ArrayList<AttributeSchema>();
         if (!attributeSchemas.containsKey(config.getName())) {
-            SCIMAttributeSchema attributeSchema =
+            AttributeSchema attributeSchema =
                     createSCIMAttributeSchema(config, subAttributeList);
             attributeSchemas.put(config.getName(), attributeSchema);
         }
@@ -195,7 +196,7 @@ public class SCIMUserSchemaExtensionBuilder {
      * @return
      */
     public SCIMAttributeSchema createSCIMAttributeSchema(ExtensionAttributeSchemaConfig attribute,
-                                                         ArrayList<SCIMAttributeSchema> subAttributeList) {
+                                                         ArrayList<AttributeSchema> subAttributeList) {
 
         return SCIMAttributeSchema.createSCIMAttributeSchema
                 (attribute.getURI(), attribute.getName(), attribute.getType(),

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONDecoder.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONDecoder.java
@@ -15,6 +15,21 @@
  */
 package org.wso2.charon3.core.encoder;
 
+import static org.wso2.charon3.core.schema.SCIMDefinitions.DataType.BINARY;
+import static org.wso2.charon3.core.schema.SCIMDefinitions.DataType.BOOLEAN;
+import static org.wso2.charon3.core.schema.SCIMDefinitions.DataType.COMPLEX;
+import static org.wso2.charon3.core.schema.SCIMDefinitions.DataType.DATE_TIME;
+import static org.wso2.charon3.core.schema.SCIMDefinitions.DataType.DECIMAL;
+import static org.wso2.charon3.core.schema.SCIMDefinitions.DataType.INTEGER;
+import static org.wso2.charon3.core.schema.SCIMDefinitions.DataType.REFERENCE;
+import static org.wso2.charon3.core.schema.SCIMDefinitions.DataType.STRING;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -37,7 +52,6 @@ import org.wso2.charon3.core.objects.bulk.BulkRequestData;
 import org.wso2.charon3.core.protocol.ResponseCodeConstants;
 import org.wso2.charon3.core.schema.AttributeSchema;
 import org.wso2.charon3.core.schema.ResourceTypeSchema;
-import org.wso2.charon3.core.schema.SCIMAttributeSchema;
 import org.wso2.charon3.core.schema.SCIMConstants;
 import org.wso2.charon3.core.schema.SCIMDefinitions;
 import org.wso2.charon3.core.schema.SCIMResourceSchemaManager;
@@ -47,21 +61,6 @@ import org.wso2.charon3.core.utils.codeutils.FilterTreeManager;
 import org.wso2.charon3.core.utils.codeutils.Node;
 import org.wso2.charon3.core.utils.codeutils.PatchOperation;
 import org.wso2.charon3.core.utils.codeutils.SearchRequest;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static org.wso2.charon3.core.schema.SCIMDefinitions.DataType.BINARY;
-import static org.wso2.charon3.core.schema.SCIMDefinitions.DataType.BOOLEAN;
-import static org.wso2.charon3.core.schema.SCIMDefinitions.DataType.COMPLEX;
-import static org.wso2.charon3.core.schema.SCIMDefinitions.DataType.DATE_TIME;
-import static org.wso2.charon3.core.schema.SCIMDefinitions.DataType.DECIMAL;
-import static org.wso2.charon3.core.schema.SCIMDefinitions.DataType.INTEGER;
-import static org.wso2.charon3.core.schema.SCIMDefinitions.DataType.REFERENCE;
-import static org.wso2.charon3.core.schema.SCIMDefinitions.DataType.STRING;
 
 /**
  * This decodes the json encoded resource string and create a SCIM object model according to the specification
@@ -308,8 +307,8 @@ public class JSONDecoder {
         ComplexAttribute complexAttribute = new ComplexAttribute(complexAttributeSchema.getName());
         Map<String, Attribute> subAttributesMap = new HashMap<String, Attribute>();
         //list of sub attributes of the complex attribute
-        List<SCIMAttributeSchema> subAttributeSchemas =
-                ((SCIMAttributeSchema) complexAttributeSchema).getSubAttributeSchemas();
+        List<AttributeSchema> subAttributeSchemas =
+                ((AttributeSchema) complexAttributeSchema).getSubAttributeSchemas();
 
         //iterate through the complex attribute schema and extract the sub attributes.
         for (AttributeSchema subAttributeSchema : subAttributeSchemas) {
@@ -356,7 +355,7 @@ public class JSONDecoder {
                     SCIMResourceSchemaManager.getInstance().getExtensionName())) {
                 if (subAttributeSchemaType.equals(COMPLEX)) {
                     //check for user defined extension's schema violation
-                    List<SCIMAttributeSchema> subList = subAttributeSchema.getSubAttributeSchemas();
+                    List<AttributeSchema> subList = subAttributeSchema.getSubAttributeSchemas();
                     for (AttributeSchema attributeSchema : subList) {
                         if (attributeSchema.getType().equals(SCIMDefinitions.DataType.COMPLEX)) {
                             String error = "Complex attribute can not have complex sub attributes";
@@ -442,10 +441,10 @@ public class JSONDecoder {
 
         ComplexAttribute complexAttribute = new ComplexAttribute(attributeSchema.getName());
         Map<String, Attribute> subAttributesMap = new HashMap<String, Attribute>();
-        List<SCIMAttributeSchema> subAttributeSchemas =
-                ((SCIMAttributeSchema) attributeSchema).getSubAttributeSchemas();
+        List<AttributeSchema> subAttributeSchemas =
+                ((AttributeSchema) attributeSchema).getSubAttributeSchemas();
 
-        for (SCIMAttributeSchema subAttributeSchema : subAttributeSchemas) {
+        for (AttributeSchema subAttributeSchema : subAttributeSchemas) {
             Object subAttributeValue = jsonObject.opt(subAttributeSchema.getName());
             //setting up a name for the complex attribute for the reference purpose
             if (subAttributeSchema.getName().equals(SCIMConstants.CommonSchemaConstants.VALUE)) {

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/AbstractValidator.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/AbstractValidator.java
@@ -86,11 +86,11 @@ public abstract class AbstractValidator {
                                                                    AttributeSchema attributeSchema) throws
             CharonException, BadRequestException {
         if (attribute != null) {
-            List<SCIMAttributeSchema> subAttributesSchemaList =
-                    ((SCIMAttributeSchema) attributeSchema).getSubAttributeSchemas();
+            List<AttributeSchema> subAttributesSchemaList =
+                    ((AttributeSchema) attributeSchema).getSubAttributeSchemas();
 
             if (subAttributesSchemaList != null) {
-                for (SCIMAttributeSchema subAttributeSchema : subAttributesSchemaList) {
+                for (AttributeSchema subAttributeSchema : subAttributesSchemaList) {
                     if (subAttributeSchema.getRequired()) {
 
                         if (attribute instanceof ComplexAttribute) {
@@ -126,8 +126,7 @@ public abstract class AbstractValidator {
                             }
                         }
                     }
-                    List<SCIMAttributeSchema> subSubAttributesSchemaList =
-                            ((SCIMAttributeSchema) subAttributeSchema).getSubAttributeSchemas();
+                    List<AttributeSchema> subSubAttributesSchemaList = subAttributeSchema.getSubAttributeSchemas();
                     if (subSubAttributesSchemaList != null) {
                         validateSCIMObjectForRequiredSubAttributes(subAttribute, subAttributeSchema);
                     }
@@ -198,10 +197,9 @@ public abstract class AbstractValidator {
     private static void removeAnyReadOnlySubAttributes(Attribute attribute,
                                                        AttributeSchema attributeSchema) throws CharonException {
         if (attribute != null) {
-            List<SCIMAttributeSchema> subAttributesSchemaList =
-                    ((SCIMAttributeSchema) attributeSchema).getSubAttributeSchemas();
+            List<AttributeSchema> subAttributesSchemaList = attributeSchema.getSubAttributeSchemas();
             if (subAttributesSchemaList != null && !subAttributesSchemaList.isEmpty()) {
-                for (SCIMAttributeSchema subAttributeSchema : subAttributesSchemaList) {
+                for (AttributeSchema subAttributeSchema : subAttributesSchemaList) {
                     if (subAttributeSchema.getMutability() == SCIMDefinitions.Mutability.READ_ONLY) {
                         if (attribute instanceof ComplexAttribute) {
                             if (attribute.getSubAttribute(subAttributeSchema.getName()) != null) {
@@ -809,7 +807,7 @@ public abstract class AbstractValidator {
         //check for sub attributes.
         AbstractAttribute newAttribute = (AbstractAttribute) newAttributeList.get(attributeSchema.getName());
         AbstractAttribute oldAttribute = (AbstractAttribute) oldAttributeList.get(attributeSchema.getName());
-        List<SCIMAttributeSchema> subAttributeSchemaList = attributeSchema.getSubAttributeSchemas();
+        List<AttributeSchema> subAttributeSchemaList = attributeSchema.getSubAttributeSchemas();
 
         if (subAttributeSchemaList != null) {
             if (SCIMResourceSchemaManager.getInstance().getExtensionName() != null) {
@@ -925,7 +923,7 @@ public abstract class AbstractValidator {
      * @throws BadRequestException
      */
     private static void checkIfReadOnlyAndImmutableExtensionAttributesModified(
-            List<SCIMAttributeSchema> subAttributeSchemaList, AbstractAttribute newAttribute,
+            List<AttributeSchema> subAttributeSchemaList, AbstractAttribute newAttribute,
             AbstractAttribute oldAttribute) throws CharonException, BadRequestException {
 
         Map<String, Attribute> newAttributeList = new HashMap<String, Attribute>();
@@ -1051,7 +1049,7 @@ public abstract class AbstractValidator {
      * @throws BadRequestException
      */
     private static void checkForReadOnlyAndImmutableInComplexAttributes(Attribute newAttribute, Attribute oldAttribute,
-                                                                        List<SCIMAttributeSchema> subAttributeSchemaList
+                                                                        List<AttributeSchema> subAttributeSchemaList
     ) throws CharonException, BadRequestException {
         //this is complex attribute case
         Map<String, Attribute> newSubAttributeList = ((ComplexAttribute) (newAttribute)).getSubAttributesList();
@@ -1125,7 +1123,7 @@ public abstract class AbstractValidator {
                 }
             } else if (attributeSchema.getType().equals(SCIMDefinitions.DataType.COMPLEX)) {
                 //this is only valid for extension schema
-                List<SCIMAttributeSchema> subAttributeSchemaList = attributeSchema.getSubAttributeSchemas();
+                List<AttributeSchema> subAttributeSchemaList = attributeSchema.getSubAttributeSchemas();
                 for (AttributeSchema subAttributeSchema : subAttributeSchemaList) {
                     if (subAttributeSchema.getMultiValued() &&
                             subAttributeSchema.getType().equals(SCIMDefinitions.DataType.COMPLEX)) {

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/AttributeSchema.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/AttributeSchema.java
@@ -65,7 +65,7 @@ public interface AttributeSchema {
 
     public void setUniqueness(SCIMDefinitions.Uniqueness uniqueness);
 
-    public List<SCIMAttributeSchema> getSubAttributeSchemas();
+    public List<AttributeSchema> getSubAttributeSchemas();
 
     public AttributeSchema getSubAttributeSchema(String subAttribute);
 

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMAttributeSchema.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMAttributeSchema.java
@@ -16,12 +16,12 @@
 
 package org.wso2.charon3.core.schema;
 
-import org.wso2.charon3.core.exceptions.CharonException;
-import org.wso2.charon3.core.utils.CopyUtil;
-
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.wso2.charon3.core.exceptions.CharonException;
+import org.wso2.charon3.core.utils.CopyUtil;
 
 /**
  * This defines the attributes schema as in SCIM Spec.
@@ -51,7 +51,7 @@ public class SCIMAttributeSchema implements AttributeSchema, Serializable {
     //A SCIM defined value that specifies the uniqueness level of an attribute.
     private SCIMDefinitions.Uniqueness uniqueness;
     //A list specifying the contained attributes. OPTIONAL.
-    private ArrayList<SCIMAttributeSchema> subAttributes;
+    private ArrayList<AttributeSchema> subAttributes;
     //A collection of suggested canonical values that MAY be used -OPTIONAL
     private ArrayList<String> canonicalValues;
     //A multi-valued array of JSON strings that indicate the SCIM resource types that may be referenced
@@ -63,7 +63,7 @@ public class SCIMAttributeSchema implements AttributeSchema, Serializable {
                                 SCIMDefinitions.Mutability mutability, SCIMDefinitions.Returned returned,
                                 SCIMDefinitions.Uniqueness uniqueness, ArrayList<String> canonicalValues,
                                 ArrayList<SCIMDefinitions.ReferenceType> referenceTypes,
-                                ArrayList<SCIMAttributeSchema> subAttributes) {
+                                ArrayList<AttributeSchema> subAttributes) {
         this.uri = uri;
         this.name = name;
         this.type = type;
@@ -88,7 +88,7 @@ public class SCIMAttributeSchema implements AttributeSchema, Serializable {
                                                                 SCIMDefinitions.Uniqueness uniqueness,
                                                                 ArrayList<String> canonicalValues,
                                                                 ArrayList<SCIMDefinitions.ReferenceType> referenceTypes,
-                                                                ArrayList<SCIMAttributeSchema> subAttributes) {
+                                                                ArrayList<AttributeSchema> subAttributes) {
 
         return new SCIMAttributeSchema(uri, name, type, multiValued, description, required, caseExact, mutability,
                 returned, uniqueness, canonicalValues, referenceTypes, subAttributes);
@@ -177,13 +177,13 @@ public class SCIMAttributeSchema implements AttributeSchema, Serializable {
     }
 
     @Override
-    public List<SCIMAttributeSchema> getSubAttributeSchemas() {
+    public List<AttributeSchema> getSubAttributeSchemas() {
         return subAttributes;
     }
 
     @Override
     public AttributeSchema getSubAttributeSchema(String subAttribute) {
-        for (SCIMAttributeSchema subAttributeSchema : subAttributes) {
+        for (AttributeSchema subAttributeSchema : subAttributes) {
             if (subAttributeSchema.getName().equals(subAttribute)) {
                 return subAttributeSchema;
             }
@@ -205,7 +205,7 @@ public class SCIMAttributeSchema implements AttributeSchema, Serializable {
         }
     }
 
-    public void setSubAttributes(ArrayList<SCIMAttributeSchema> subAttributes) {
+    public void setSubAttributes(ArrayList<AttributeSchema> subAttributes) {
         this.subAttributes = subAttributes;
     }
 

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMResourceSchemaManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMResourceSchemaManager.java
@@ -42,7 +42,7 @@ public class SCIMResourceSchemaManager {
     public SCIMResourceTypeSchema getUserResourceSchema() {
 
 
-        SCIMAttributeSchema schemaExtension = SCIMUserSchemaExtensionBuilder.getInstance().getExtensionSchema();
+        AttributeSchema schemaExtension = SCIMUserSchemaExtensionBuilder.getInstance().getExtensionSchema();
         if (schemaExtension != null) {
             return SCIMResourceTypeSchema.createSCIMResourceSchema(
                     new ArrayList<String>(Arrays.asList(SCIMConstants.USER_CORE_SCHEMA_URI, schemaExtension.getURI())),
@@ -79,7 +79,7 @@ public class SCIMResourceSchemaManager {
      * @return
      */
     public Boolean isExtensionSet() {
-        SCIMAttributeSchema schemaExtension = SCIMUserSchemaExtensionBuilder.getInstance().getExtensionSchema();
+        AttributeSchema schemaExtension = SCIMUserSchemaExtensionBuilder.getInstance().getExtensionSchema();
         if (schemaExtension != null) {
             return true;
         } else {
@@ -93,7 +93,7 @@ public class SCIMResourceSchemaManager {
      * @return
      */
     public String getExtensionName() {
-        SCIMAttributeSchema schemaExtension = SCIMUserSchemaExtensionBuilder.getInstance().getExtensionSchema();
+        AttributeSchema schemaExtension = SCIMUserSchemaExtensionBuilder.getInstance().getExtensionSchema();
         if (schemaExtension == null) {
             return null;
         }
@@ -106,7 +106,7 @@ public class SCIMResourceSchemaManager {
      * @return
      */
     public String getExtensionURI() {
-        SCIMAttributeSchema schemaExtension = SCIMUserSchemaExtensionBuilder.getInstance().getExtensionSchema();
+        AttributeSchema schemaExtension = SCIMUserSchemaExtensionBuilder.getInstance().getExtensionSchema();
         if (schemaExtension == null) {
             return null;
         }
@@ -119,7 +119,7 @@ public class SCIMResourceSchemaManager {
      * @return
      */
     public boolean getExtensionRequired() {
-        SCIMAttributeSchema schemaExtension = SCIMUserSchemaExtensionBuilder.getInstance().getExtensionSchema();
+        AttributeSchema schemaExtension = SCIMUserSchemaExtensionBuilder.getInstance().getExtensionSchema();
         if (schemaExtension == null) {
             return false;
         }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMSchemaDefinitions.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMSchemaDefinitions.java
@@ -110,7 +110,7 @@ public class SCIMSchemaDefinitions {
                     false,
                     SCIMDefinitions.Mutability.READ_ONLY, SCIMDefinitions.Returned.DEFAULT,
                     SCIMDefinitions.Uniqueness.NONE, null, null,
-                    new ArrayList<SCIMAttributeSchema>(Arrays.asList(RESOURCE_TYPE, CREATED, LAST_MODIFIED, LOCATION,
+                    new ArrayList<AttributeSchema>(Arrays.asList(RESOURCE_TYPE, CREATED, LAST_MODIFIED, LOCATION,
                             VERSION)));
 
 
@@ -615,7 +615,7 @@ public class SCIMSchemaDefinitions {
                         false,
                         SCIMDefinitions.Mutability.READ_WRITE, SCIMDefinitions.Returned.DEFAULT,
                         SCIMDefinitions.Uniqueness.NONE, null, null,
-                        new ArrayList<SCIMAttributeSchema>(Arrays.asList(FORMATTED, FAMILY_NAME, GIVEN_NAME,
+                        new ArrayList<AttributeSchema>(Arrays.asList(FORMATTED, FAMILY_NAME, GIVEN_NAME,
                                 MIDDLE_NAME,
                                 HONORIFIC_PREFIX, HONORIFIC_SUFFIX)));
 
@@ -720,7 +720,7 @@ public class SCIMSchemaDefinitions {
                         false,
                         SCIMDefinitions.Mutability.READ_WRITE, SCIMDefinitions.Returned.DEFAULT,
                         SCIMDefinitions.Uniqueness.NONE, null, null,
-                        new ArrayList<SCIMAttributeSchema>(Arrays.asList(EMAIL_VALUE, EMAIL_DISPLAY, EMAIL_TYPE,
+                        new ArrayList<AttributeSchema>(Arrays.asList(EMAIL_VALUE, EMAIL_DISPLAY, EMAIL_TYPE,
                                 EMAIL_PRIMARY)));
 
         //Phone numbers for the User.
@@ -731,7 +731,7 @@ public class SCIMSchemaDefinitions {
                         false, false,
                         SCIMDefinitions.Mutability.READ_WRITE, SCIMDefinitions.Returned.DEFAULT,
                         SCIMDefinitions.Uniqueness.NONE, null, null,
-                        new ArrayList<SCIMAttributeSchema>(Arrays.asList(PHONE_NUMBERS_VALUE, PHONE_NUMBERS_DISPLAY,
+                        new ArrayList<AttributeSchema>(Arrays.asList(PHONE_NUMBERS_VALUE, PHONE_NUMBERS_DISPLAY,
                                 PHONE_NUMBERS_TYPE, PHONE_NUMBERS_PRIMARY)));
 
         //Instant messaging addresses for the User.
@@ -742,7 +742,7 @@ public class SCIMSchemaDefinitions {
                         false,
                         SCIMDefinitions.Mutability.READ_WRITE, SCIMDefinitions.Returned.DEFAULT,
                         SCIMDefinitions.Uniqueness.NONE, null, null,
-                        new ArrayList<SCIMAttributeSchema>(Arrays.asList(IMS_VALUE, IMS_DISPLAY, IMS_TYPE,
+                        new ArrayList<AttributeSchema>(Arrays.asList(IMS_VALUE, IMS_DISPLAY, IMS_TYPE,
                                 IMS_PRIMARY)));
 
         //URLs of photos of the User.
@@ -753,7 +753,7 @@ public class SCIMSchemaDefinitions {
                         false,
                         SCIMDefinitions.Mutability.READ_WRITE, SCIMDefinitions.Returned.DEFAULT,
                         SCIMDefinitions.Uniqueness.NONE, null, null,
-                        new ArrayList<SCIMAttributeSchema>(Arrays.asList(PHOTOS_VALUE, PHOTOS_DISPLAY, PHOTOS_TYPE,
+                        new ArrayList<AttributeSchema>(Arrays.asList(PHOTOS_VALUE, PHOTOS_DISPLAY, PHOTOS_TYPE,
                                 PHOTOS_PRIMARY)));
 
         //A physical mailing address for this User.
@@ -764,7 +764,7 @@ public class SCIMSchemaDefinitions {
                         false, false,
                         SCIMDefinitions.Mutability.READ_WRITE, SCIMDefinitions.Returned.DEFAULT,
                         SCIMDefinitions.Uniqueness.NONE, null, null,
-                        new ArrayList<SCIMAttributeSchema>(Arrays.asList(ADDRESSES_FORMATTED,
+                        new ArrayList<AttributeSchema>(Arrays.asList(ADDRESSES_FORMATTED,
                                 ADDRESSES_STREET_ADDRESS, ADDRESSES_LOCALITY,
                                 ADDRESSES_REGION, ADDRESSES_POSTAL_CODE, ADDRESSES_COUNTRY, ADDRESSES_TYPE,
                                 ADDRESSES_PRIMARY)));
@@ -778,7 +778,7 @@ public class SCIMSchemaDefinitions {
                         false,
                         SCIMDefinitions.Mutability.READ_ONLY, SCIMDefinitions.Returned.DEFAULT,
                         SCIMDefinitions.Uniqueness.NONE, null, null,
-                        new ArrayList<SCIMAttributeSchema>(Arrays.asList(GROUP_VALUE, GROUP_REF, GROUP_DISPLAY,
+                        new ArrayList<AttributeSchema>(Arrays.asList(GROUP_VALUE, GROUP_REF, GROUP_DISPLAY,
                                 GROUP_TYPE)));
 
         //A list of entitlements for the User that represent a thing the User has.
@@ -789,7 +789,7 @@ public class SCIMSchemaDefinitions {
                         false, false,
                         SCIMDefinitions.Mutability.READ_WRITE, SCIMDefinitions.Returned.DEFAULT,
                         SCIMDefinitions.Uniqueness.NONE, null, null,
-                        new ArrayList<SCIMAttributeSchema>(Arrays.asList(ENTITLEMENTS_VALUE, ENTITLEMENTS_DISPLAY,
+                        new ArrayList<AttributeSchema>(Arrays.asList(ENTITLEMENTS_VALUE, ENTITLEMENTS_DISPLAY,
                                 ENTITLEMENTS_TYPE, ENTITLEMENTS_PRIMARY)));
 
         //A list of roles for the User that collectively represent who the User is, e.g., 'Student', 'Faculty'.
@@ -800,7 +800,7 @@ public class SCIMSchemaDefinitions {
                         false,
                         SCIMDefinitions.Mutability.READ_WRITE, SCIMDefinitions.Returned.DEFAULT,
                         SCIMDefinitions.Uniqueness.NONE, null, null,
-                        new ArrayList<SCIMAttributeSchema>(Arrays.asList(ROLES_VALUE, ROLES_DISPLAY,
+                        new ArrayList<AttributeSchema>(Arrays.asList(ROLES_VALUE, ROLES_DISPLAY,
                                 ROLES_TYPE, ROLES_PRIMARY)));
 
         //A list of roles for the User that collectively represent who the User is, e.g., 'Student', 'Faculty'.
@@ -811,7 +811,7 @@ public class SCIMSchemaDefinitions {
                                 .X509CERTIFICATES_DESC, false, false,
                         SCIMDefinitions.Mutability.READ_WRITE, SCIMDefinitions.Returned.DEFAULT,
                         SCIMDefinitions.Uniqueness.NONE, null, null,
-                        new ArrayList<SCIMAttributeSchema>(Arrays.asList(X509CERTIFICATES_VALUE,
+                        new ArrayList<AttributeSchema>(Arrays.asList(X509CERTIFICATES_VALUE,
                                 X509CERTIFICATES_DISPLAY,
                                 X509CERTIFICATES_TYPE, X509CERTIFICATES_PRIMARY)));
 
@@ -877,7 +877,7 @@ public class SCIMSchemaDefinitions {
                         SCIMDefinitions.DataType.COMPLEX, true, SCIMConstants.GroupSchemaConstants.MEMBERS_DESC,
                         false, false,
                         SCIMDefinitions.Mutability.READ_WRITE, SCIMDefinitions.Returned.DEFAULT,
-                        SCIMDefinitions.Uniqueness.NONE, null, null, new ArrayList<SCIMAttributeSchema>(Arrays.asList
+                        SCIMDefinitions.Uniqueness.NONE, null, null, new ArrayList<AttributeSchema>(Arrays.asList
                                 (VALUE, REF, DISPLAY)));
     }
 
@@ -1053,7 +1053,7 @@ public class SCIMSchemaDefinitions {
                         SCIMConstants.ServiceProviderConfigSchemaConstants.PATCH_DESC, true, false,
                         SCIMDefinitions.Mutability.READ_ONLY, SCIMDefinitions.Returned.DEFAULT,
                         SCIMDefinitions.Uniqueness.NONE, null, null,
-                        new ArrayList<SCIMAttributeSchema>(Arrays.asList(PATCH_SUPPORTED)));
+                        new ArrayList<AttributeSchema>(Arrays.asList(PATCH_SUPPORTED)));
 
         public static final SCIMAttributeSchema BULK =
                 SCIMAttributeSchema.createSCIMAttributeSchema(
@@ -1063,7 +1063,7 @@ public class SCIMSchemaDefinitions {
                         SCIMConstants.ServiceProviderConfigSchemaConstants.BULK_DESC, true, false,
                         SCIMDefinitions.Mutability.READ_ONLY, SCIMDefinitions.Returned.DEFAULT,
                         SCIMDefinitions.Uniqueness.NONE, null, null,
-                        new ArrayList<SCIMAttributeSchema>(Arrays.asList(BULK_SUPPORTED, MAX_OPERATIONS,
+                        new ArrayList<AttributeSchema>(Arrays.asList(BULK_SUPPORTED, MAX_OPERATIONS,
                                 MAX_PAYLOAD_SIZE)));
 
         public static final SCIMAttributeSchema FILTER =
@@ -1074,7 +1074,7 @@ public class SCIMSchemaDefinitions {
                         SCIMConstants.ServiceProviderConfigSchemaConstants.FILTERS_DESC, true, false,
                         SCIMDefinitions.Mutability.READ_ONLY, SCIMDefinitions.Returned.DEFAULT,
                         SCIMDefinitions.Uniqueness.NONE, null, null,
-                        new ArrayList<SCIMAttributeSchema>(Arrays.asList(FILTER_SUPPORTED, MAX_RESULTS)));
+                        new ArrayList<AttributeSchema>(Arrays.asList(FILTER_SUPPORTED, MAX_RESULTS)));
 
         public static final SCIMAttributeSchema CHANGE_PASSWORD =
                 SCIMAttributeSchema.createSCIMAttributeSchema(
@@ -1084,7 +1084,7 @@ public class SCIMSchemaDefinitions {
                         SCIMConstants.ServiceProviderConfigSchemaConstants.CHANGE_PASSWORD_DESC, true, false,
                         SCIMDefinitions.Mutability.READ_ONLY, SCIMDefinitions.Returned.DEFAULT,
                         SCIMDefinitions.Uniqueness.NONE, null, null,
-                        new ArrayList<SCIMAttributeSchema>(Arrays.asList(CHANGE_PASSWORD_SUPPORTED)));
+                        new ArrayList<AttributeSchema>(Arrays.asList(CHANGE_PASSWORD_SUPPORTED)));
 
         public static final SCIMAttributeSchema SORT =
                 SCIMAttributeSchema.createSCIMAttributeSchema(
@@ -1094,7 +1094,7 @@ public class SCIMSchemaDefinitions {
                         SCIMConstants.ServiceProviderConfigSchemaConstants.SORT_DESC, true, false,
                         SCIMDefinitions.Mutability.READ_ONLY, SCIMDefinitions.Returned.DEFAULT,
                         SCIMDefinitions.Uniqueness.NONE, null, null,
-                        new ArrayList<SCIMAttributeSchema>(Arrays.asList(SORT_SUPPORTED)));
+                        new ArrayList<AttributeSchema>(Arrays.asList(SORT_SUPPORTED)));
 
         public static final SCIMAttributeSchema ETAG =
                 SCIMAttributeSchema.createSCIMAttributeSchema(
@@ -1104,7 +1104,7 @@ public class SCIMSchemaDefinitions {
                         SCIMConstants.ServiceProviderConfigSchemaConstants.ETAG_DESC, true, false,
                         SCIMDefinitions.Mutability.READ_ONLY, SCIMDefinitions.Returned.DEFAULT,
                         SCIMDefinitions.Uniqueness.NONE, null, null,
-                        new ArrayList<SCIMAttributeSchema>(Arrays.asList(ETAG_SUPPORTED)));
+                        new ArrayList<AttributeSchema>(Arrays.asList(ETAG_SUPPORTED)));
 
         public static final SCIMAttributeSchema AUTHENTICATION_SCHEMES =
                 SCIMAttributeSchema.createSCIMAttributeSchema(
@@ -1114,7 +1114,7 @@ public class SCIMSchemaDefinitions {
                         SCIMConstants.ServiceProviderConfigSchemaConstants.AUTHENTICATION_SCHEMAS_DESC, true, false,
                         SCIMDefinitions.Mutability.READ_ONLY, SCIMDefinitions.Returned.DEFAULT,
                         SCIMDefinitions.Uniqueness.NONE, null, null,
-                        new ArrayList<SCIMAttributeSchema>(Arrays.asList(NAME, DESCRIPTION,
+                        new ArrayList<AttributeSchema>(Arrays.asList(NAME, DESCRIPTION,
                                 SPEC_URI, AUTHENTICATION_SCHEMES_DOCUMENTATION_URI, TYPE, PRIMARY)));
 
 
@@ -1204,7 +1204,7 @@ public class SCIMSchemaDefinitions {
                         SCIMConstants.ResourceTypeSchemaConstants.SCHEMA_EXTENSIONS_DESC, true, false,
                         SCIMDefinitions.Mutability.READ_ONLY, SCIMDefinitions.Returned.DEFAULT,
                         SCIMDefinitions.Uniqueness.NONE, null, null,
-                        new ArrayList<SCIMAttributeSchema>(Arrays.asList(SCHEMA_EXTENSION_SCHEMA,
+                        new ArrayList<AttributeSchema>(Arrays.asList(SCHEMA_EXTENSION_SCHEMA,
                                 SCHEMA_EXTENSION_REQUIRED)));
 
 
@@ -1239,7 +1239,6 @@ public class SCIMSchemaDefinitions {
                     SCIMUserSchemaDefinition.ENTITLEMENTS,
                     SCIMUserSchemaDefinition.ROLES,
                     SCIMUserSchemaDefinition.X509CERTIFICATES);
-
     /*
      * **********SCIM defined Group Resource Schema.****************************
      */

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/AttributeUtil.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/AttributeUtil.java
@@ -15,21 +15,20 @@
  */
 package org.wso2.charon3.core.utils;
 
-import org.json.JSONObject;
-import org.wso2.charon3.core.exceptions.BadRequestException;
-import org.wso2.charon3.core.exceptions.CharonException;
-import org.wso2.charon3.core.protocol.ResponseCodeConstants;
-import org.wso2.charon3.core.schema.AttributeSchema;
-import org.wso2.charon3.core.schema.SCIMAttributeSchema;
-import org.wso2.charon3.core.schema.SCIMConstants;
-import org.wso2.charon3.core.schema.SCIMDefinitions;
-import org.wso2.charon3.core.schema.SCIMResourceTypeSchema;
-
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
+
+import org.json.JSONObject;
+import org.wso2.charon3.core.exceptions.BadRequestException;
+import org.wso2.charon3.core.exceptions.CharonException;
+import org.wso2.charon3.core.protocol.ResponseCodeConstants;
+import org.wso2.charon3.core.schema.AttributeSchema;
+import org.wso2.charon3.core.schema.SCIMConstants;
+import org.wso2.charon3.core.schema.SCIMDefinitions;
+import org.wso2.charon3.core.schema.SCIMResourceTypeSchema;
 
 /**
  * This class acts as an utility class for attributes.
@@ -188,7 +187,7 @@ public class AttributeUtil {
             }
             // check in sub attributes
             String subAttributeURI =
-                    checkSCIMSubAttributeURIs(((SCIMAttributeSchema) attributeSchema).getSubAttributeSchemas(),
+                    checkSCIMSubAttributeURIs(attributeSchema.getSubAttributeSchemas(),
                             attributeSchema, attributeName);
             if (subAttributeURI != null) {
                 return subAttributeURI;
@@ -219,24 +218,24 @@ public class AttributeUtil {
      * @param attributeSchema
      * @param attributeName   @return
      */
-    private static String checkSCIMSubAttributeURIs(List<SCIMAttributeSchema> subAttributes,
+    private static String checkSCIMSubAttributeURIs(List<AttributeSchema> subAttributes,
                                                     AttributeSchema attributeSchema, String attributeName) {
         if (subAttributes != null) {
-            Iterator<SCIMAttributeSchema> subsIterator = subAttributes.iterator();
+            Iterator<AttributeSchema> subsIterator = subAttributes.iterator();
 
             while (subsIterator.hasNext()) {
-                SCIMAttributeSchema subAttributeSchema = subsIterator.next();
+                AttributeSchema subAttributeSchema = subsIterator.next();
                 if ((attributeSchema.getName() + "." + subAttributeSchema.getName()).equalsIgnoreCase(attributeName) ||
                         subAttributeSchema.getURI().equals(attributeName)) {
                     return subAttributeSchema.getURI();
                 }
                 if (subAttributeSchema.getType().equals(SCIMDefinitions.DataType.COMPLEX)) {
-                    List<SCIMAttributeSchema> subSubAttributeSchemas = subAttributeSchema.getSubAttributeSchemas();
+                    List<AttributeSchema> subSubAttributeSchemas = subAttributeSchema.getSubAttributeSchemas();
                     if (subSubAttributeSchemas != null) {
-                        Iterator<SCIMAttributeSchema> subSubsIterator = subSubAttributeSchemas.iterator();
+                        Iterator<AttributeSchema> subSubsIterator = subSubAttributeSchemas.iterator();
 
                         while (subSubsIterator.hasNext()) {
-                            SCIMAttributeSchema subSubAttributeSchema = subSubsIterator.next();
+                            AttributeSchema subSubAttributeSchema = subSubsIterator.next();
                             if ((attributeSchema.getName() + "." + subAttributeSchema.getName() + "." +
                                     subSubAttributeSchema.getName()).equalsIgnoreCase(attributeName) ||
                                     subAttributeSchema.getURI().equals(attributeName)) {

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/ResourceManagerUtil.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/ResourceManagerUtil.java
@@ -16,19 +16,18 @@
 
 package org.wso2.charon3.core.utils;
 
-import org.wso2.charon3.core.config.CharonConfiguration;
-import org.wso2.charon3.core.exceptions.BadRequestException;
-import org.wso2.charon3.core.exceptions.CharonException;
-import org.wso2.charon3.core.schema.AttributeSchema;
-import org.wso2.charon3.core.schema.SCIMAttributeSchema;
-import org.wso2.charon3.core.schema.SCIMDefinitions;
-import org.wso2.charon3.core.schema.SCIMResourceTypeSchema;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.wso2.charon3.core.config.CharonConfiguration;
+import org.wso2.charon3.core.exceptions.BadRequestException;
+import org.wso2.charon3.core.exceptions.CharonException;
+import org.wso2.charon3.core.schema.AttributeSchema;
+import org.wso2.charon3.core.schema.SCIMDefinitions;
+import org.wso2.charon3.core.schema.SCIMResourceTypeSchema;
 /**
  * This class will act as a support class for endpoints.
  */
@@ -138,9 +137,9 @@ public class ResourceManagerUtil {
                 }
             }
             if (realAttributeSchema != null) {
-                List<SCIMAttributeSchema> subAttributeList = attributeSchema.getSubAttributeSchemas();
+                List<AttributeSchema> subAttributeList = attributeSchema.getSubAttributeSchemas();
 
-                for (SCIMAttributeSchema subAttributeSchema : subAttributeList) {
+                for (AttributeSchema subAttributeSchema : subAttributeList) {
 
                     //check for never/request attributes.
                     if (subAttributeSchema.getReturned().equals(SCIMDefinitions.Returned.NEVER)) {
@@ -217,7 +216,7 @@ public class ResourceManagerUtil {
             AttributeSchema realAttributeSchema = null;
             //need to get the right reference first as we are going to delete by reference
             for (AttributeSchema schema : attributeSchemaArrayList) {
-                List<SCIMAttributeSchema> subSchemas = schema.getSubAttributeSchemas();
+                List<AttributeSchema> subSchemas = schema.getSubAttributeSchemas();
                 if (subSchemas != null) {
                     for (AttributeSchema subSchema : subSchemas) {
                         if (subSchema.getURI().equals(subAttribute.getURI())) {
@@ -228,9 +227,9 @@ public class ResourceManagerUtil {
                 }
             }
             if (realAttributeSchema != null) {
-                List<SCIMAttributeSchema> subSubAttributeList = subAttribute.getSubAttributeSchemas();
+                List<AttributeSchema> subSubAttributeList = subAttribute.getSubAttributeSchemas();
 
-                for (SCIMAttributeSchema subSubAttributeSchema : subSubAttributeList) {
+                for (AttributeSchema subSubAttributeSchema : subSubAttributeList) {
 
                     //check for never/request attributes.
                     if (subSubAttributeSchema.getReturned().equals(SCIMDefinitions.Returned.NEVER)) {
@@ -286,17 +285,17 @@ public class ResourceManagerUtil {
     private static boolean isSubAttributeExistsInList(List<String> requestedAttributes, AttributeSchema
             attributeSchema) {
         if (attributeSchema.getType().equals(SCIMDefinitions.DataType.COMPLEX)) {
-            List<SCIMAttributeSchema> subAttributeSchemas = attributeSchema.getSubAttributeSchemas();
+            List<AttributeSchema> subAttributeSchemas = attributeSchema.getSubAttributeSchemas();
 
-            for (SCIMAttributeSchema subAttributeSchema : subAttributeSchemas) {
+            for (AttributeSchema subAttributeSchema : subAttributeSchemas) {
                 if (requestedAttributes.contains(attributeSchema.getName() + "." + subAttributeSchema.getName())) {
                     return true;
                 }
 
                 if (subAttributeSchema.getType().equals(SCIMDefinitions.DataType.COMPLEX)) {
-                    List<SCIMAttributeSchema> subSubAttributeSchemas = subAttributeSchema.getSubAttributeSchemas();
+                    List<AttributeSchema> subSubAttributeSchemas = subAttributeSchema.getSubAttributeSchemas();
 
-                    for (SCIMAttributeSchema subSubAttributeSchema : subSubAttributeSchemas) {
+                    for (AttributeSchema subSubAttributeSchema : subSubAttributeSchemas) {
                         if (requestedAttributes.contains(
                                 attributeSchema.getName() + "." +
                                         subAttributeSchema.getName() + "." +
@@ -325,9 +324,9 @@ public class ResourceManagerUtil {
                                                          AttributeSchema subAttributeSchema) {
 
         if (subAttributeSchema.getType().equals(SCIMDefinitions.DataType.COMPLEX)) {
-            List<SCIMAttributeSchema> subSubAttributeSchemas = subAttributeSchema.getSubAttributeSchemas();
+            List<AttributeSchema> subSubAttributeSchemas = subAttributeSchema.getSubAttributeSchemas();
 
-            for (SCIMAttributeSchema subSubAttributeSchema : subSubAttributeSchemas) {
+            for (AttributeSchema subSubAttributeSchema : subSubAttributeSchemas) {
                 if (requestedAttributes.contains(attributeSchema.getName() + "." +
                         subAttributeSchema.getName() + "." + subSubAttributeSchema.getName())) {
                     return true;
@@ -350,11 +349,11 @@ public class ResourceManagerUtil {
         Map<String, Boolean> uriList = new HashMap<>();
         for (AttributeSchema schema : schemas) {
             if (schema.getType().equals(SCIMDefinitions.DataType.COMPLEX)) {
-                List<SCIMAttributeSchema> subAttributeSchemas = schema.getSubAttributeSchemas();
-                for (SCIMAttributeSchema subAttributeSchema : subAttributeSchemas) {
+                List<AttributeSchema> subAttributeSchemas = schema.getSubAttributeSchemas();
+                for (AttributeSchema subAttributeSchema : subAttributeSchemas) {
                     if (subAttributeSchema.getType().equals(SCIMDefinitions.DataType.COMPLEX)) {
-                        List<SCIMAttributeSchema> subSubAttributeSchemas = subAttributeSchema.getSubAttributeSchemas();
-                        for (SCIMAttributeSchema subSubAttributeSchema : subSubAttributeSchemas) {
+                        List<AttributeSchema> subSubAttributeSchemas = subAttributeSchema.getSubAttributeSchemas();
+                        for (AttributeSchema subSubAttributeSchema : subSubAttributeSchemas) {
                             uriList.put(subSubAttributeSchema.getURI(), subAttributeSchema.getMultiValued());
                         }
                     } else {

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/SchemaUtil.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/SchemaUtil.java
@@ -18,14 +18,12 @@
 
 package org.wso2.charon3.core.utils;
 
+import java.util.List;
+
 import org.wso2.charon3.core.schema.AttributeSchema;
 import org.wso2.charon3.core.schema.ResourceTypeSchema;
-import org.wso2.charon3.core.schema.SCIMAttributeSchema;
 import org.wso2.charon3.core.schema.SCIMDefinitions;
 import org.wso2.charon3.core.schema.SCIMResourceTypeSchema;
-
-
-import java.util.List;
 
 /**
  * Attribute schema related supportutils can be found here.
@@ -50,7 +48,7 @@ public class SchemaUtil {
                 }
                 if (attributeSchema.getType().equals(SCIMDefinitions.DataType.COMPLEX)) {
                     if (attributeSchema.getMultiValued()) {
-                        List<SCIMAttributeSchema> subAttributeSchemaList = attributeSchema.getSubAttributeSchemas();
+                        List<AttributeSchema> subAttributeSchemaList = attributeSchema.getSubAttributeSchemas();
                         for (AttributeSchema subAttributeSchema : subAttributeSchemaList) {
                             if (attributeFullName.equals
                                     (attributeSchema.getName() + "." + subAttributeSchema.getName())) {
@@ -58,7 +56,7 @@ public class SchemaUtil {
                             }
                         }
                     } else {
-                        List<SCIMAttributeSchema> subAttributeSchemaList = attributeSchema.getSubAttributeSchemas();
+                        List<AttributeSchema> subAttributeSchemaList = attributeSchema.getSubAttributeSchemas();
                         for (AttributeSchema subAttributeSchema : subAttributeSchemaList) {
                             if (attributeFullName.equals
                                     (attributeSchema.getName() + "." + subAttributeSchema.getName())) {
@@ -66,7 +64,7 @@ public class SchemaUtil {
                             }
                             if (subAttributeSchema.getType().equals(SCIMDefinitions.DataType.COMPLEX)) {
                                 // this is only valid for extension schema
-                                List<SCIMAttributeSchema> subSubAttributeSchemaList =
+                                List<AttributeSchema> subSubAttributeSchemaList =
                                         subAttributeSchema.getSubAttributeSchemas();
                                 for (AttributeSchema subSubAttributeSchema : subSubAttributeSchemaList) {
                                     if (attributeFullName.equals(attributeSchema.getName() + "." +


### PR DESCRIPTION
The interface `org.wso2.charon3.core.schema.AttributeSchema` has the method `getSubAttributeSchemas` to retrieve all sub attribute schemas.
Unfortunately this method does not return a list of interfaces (`List<AttributeSchema>`), but a list of implementations (`List<SCIMAttributeSchema>`). This is a bad design smell and is corrected with this commit.