### PR TITLE
Migrate from java.util.Date to java.time.Instant

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/attributes/DefaultAttributeFactory.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/attributes/DefaultAttributeFactory.java
@@ -15,13 +15,13 @@
  */
 package org.wso2.charon3.core.attributes;
 
-import java.time.Instant;
-
 import org.wso2.charon3.core.exceptions.BadRequestException;
 import org.wso2.charon3.core.exceptions.CharonException;
 import org.wso2.charon3.core.protocol.ResponseCodeConstants;
 import org.wso2.charon3.core.schema.AttributeSchema;
 import org.wso2.charon3.core.schema.SCIMDefinitions;
+
+import java.time.Instant;
 
 /**
  * Default implementation of AttributeFactory according to SCIM Schema spec.

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/attributes/DefaultAttributeFactory.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/attributes/DefaultAttributeFactory.java
@@ -15,13 +15,13 @@
  */
 package org.wso2.charon3.core.attributes;
 
+import java.time.Instant;
+
 import org.wso2.charon3.core.exceptions.BadRequestException;
 import org.wso2.charon3.core.exceptions.CharonException;
 import org.wso2.charon3.core.protocol.ResponseCodeConstants;
 import org.wso2.charon3.core.schema.AttributeSchema;
 import org.wso2.charon3.core.schema.SCIMDefinitions;
-
-import java.util.Date;
 
 /**
  * Default implementation of AttributeFactory according to SCIM Schema spec.
@@ -111,7 +111,7 @@ public class DefaultAttributeFactory {
             case INTEGER:
                 return attributeValue instanceof Integer;
             case DATE_TIME:
-                return attributeValue instanceof Date;
+                return attributeValue instanceof Instant;
             case BINARY:
                 return attributeValue instanceof Byte[];
             case REFERENCE:

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/attributes/SimpleAttribute.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/attributes/SimpleAttribute.java
@@ -15,11 +15,11 @@
  */
 package org.wso2.charon3.core.attributes;
 
-import java.time.Instant;
-import java.util.Date;
-
 import org.wso2.charon3.core.exceptions.CharonException;
 import org.wso2.charon3.core.schema.SCIMDefinitions;
+
+import java.time.Instant;
+import java.util.Date;
 
 /**
  * This class is a blueprint of SimpleAttribute defined in SCIM Core Schema Spec.

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/attributes/SimpleAttribute.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/attributes/SimpleAttribute.java
@@ -15,10 +15,11 @@
  */
 package org.wso2.charon3.core.attributes;
 
+import java.time.Instant;
+import java.util.Date;
+
 import org.wso2.charon3.core.exceptions.CharonException;
 import org.wso2.charon3.core.schema.SCIMDefinitions;
-
-import java.util.Date;
 
 /**
  * This class is a blueprint of SimpleAttribute defined in SCIM Core Schema Spec.
@@ -86,9 +87,20 @@ public class SimpleAttribute extends AbstractAttribute {
      * @return
      * @throws CharonException
      */
+    @Deprecated
     public Date getDateValue() throws CharonException {
+        Instant instant = getInstantValue();
+        return instant != null ? new Date(instant.toEpochMilli()) : null;
+    }
+
+    /*
+     * return the date type of the attribute value
+     * @return
+     * @throws CharonException
+     */
+    public Instant getInstantValue() throws CharonException {
         if (this.type.equals(SCIMDefinitions.DataType.DATE_TIME)) {
-            return (Date) this.value;
+            return (Instant) this.value;
         } else {
             throw new CharonException("Datatype doesn\'t match the datatype of the attribute value");
         }
@@ -96,7 +108,9 @@ public class SimpleAttribute extends AbstractAttribute {
 
     /*
      * return boolean type of the attribute value
+     * 
      * @return
+     * 
      * @throws CharonException
      */
     public Boolean getBooleanValue() throws CharonException {
@@ -109,11 +123,12 @@ public class SimpleAttribute extends AbstractAttribute {
 
     /*
      * uodate the attribute value
+     * 
      * @param value
+     * 
      * @throws CharonException
      */
     public void updateValue(Object value) throws CharonException {
-            this.value = value;
-
+        this.value = value;
     }
 }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONEncoder.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONEncoder.java
@@ -15,12 +15,6 @@
  */
 package org.wso2.charon3.core.encoder;
 
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -43,6 +37,12 @@ import org.wso2.charon3.core.schema.SCIMConstants;
 import org.wso2.charon3.core.schema.SCIMDefinitions;
 import org.wso2.charon3.core.schema.SCIMResourceSchemaManager;
 import org.wso2.charon3.core.utils.AttributeUtil;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * This encodes the in the json format.

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONEncoder.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONEncoder.java
@@ -15,6 +15,12 @@
  */
 package org.wso2.charon3.core.encoder;
 
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -37,12 +43,6 @@ import org.wso2.charon3.core.schema.SCIMConstants;
 import org.wso2.charon3.core.schema.SCIMDefinitions;
 import org.wso2.charon3.core.schema.SCIMResourceSchemaManager;
 import org.wso2.charon3.core.utils.AttributeUtil;
-
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * This encodes the in the json format.
@@ -169,7 +169,7 @@ public class JSONEncoder {
             //if type is DateTime, convert before encoding.
             if (attribute.getType() != null && attribute.getType() == SCIMDefinitions.DataType.DATE_TIME) {
                 rootObject.put(attribute.getName(),
-                        AttributeUtil.formatDateTime((Date) attribute.getValue()));
+                        AttributeUtil.formatDateTime((Instant) attribute.getValue()));
                 return;
             }
             rootObject.put(attribute.getName(), attribute.getValue());
@@ -219,7 +219,7 @@ public class JSONEncoder {
             if (attributeValue.getType() != null &&
                     attributeValue.getType() == SCIMDefinitions.DataType.DATE_TIME) {
                 attributeValueObject.put(attributeValue.getName(),
-                        AttributeUtil.formatDateTime((Date) attributeValue.getValue()));
+                        AttributeUtil.formatDateTime((Instant) attributeValue.getValue()));
                 return;
             }
             attributeValueObject.put(attributeValue.getName(), attributeValue.getValue());

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/AbstractSCIMObject.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/AbstractSCIMObject.java
@@ -15,6 +15,13 @@
  */
 package org.wso2.charon3.core.objects;
 
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.wso2.charon3.core.attributes.Attribute;
 import org.wso2.charon3.core.attributes.ComplexAttribute;
 import org.wso2.charon3.core.attributes.DefaultAttributeFactory;
@@ -26,12 +33,6 @@ import org.wso2.charon3.core.schema.ResourceTypeSchema;
 import org.wso2.charon3.core.schema.SCIMConstants;
 import org.wso2.charon3.core.schema.SCIMDefinitions;
 import org.wso2.charon3.core.schema.SCIMSchemaDefinitions;
-
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 
 /**
@@ -220,10 +221,20 @@ public class AbstractSCIMObject implements SCIMObject {
      *
      * @param createdDate
      */
+    @Deprecated
     public void setCreatedDate(Date createdDate) throws CharonException, BadRequestException {
+        setCreatedInstant(createdDate == null ? null : createdDate.toInstant());
+    }
+
+    /*
+     * set the created date and time of the resource
+     *
+     * @param createdDate
+     */
+    public void setCreatedInstant(Instant created) throws CharonException, BadRequestException {
         //create the created date attribute as defined in schema.
         SimpleAttribute createdDateAttribute = new SimpleAttribute(
-                SCIMConstants.CommonSchemaConstants.CREATED, createdDate);
+                SCIMConstants.CommonSchemaConstants.CREATED, created);
         createdDateAttribute = (SimpleAttribute) DefaultAttributeFactory.createAttribute(
                 SCIMSchemaDefinitions.CREATED, createdDateAttribute);
         //check meta complex attribute already exist.
@@ -251,11 +262,21 @@ public class AbstractSCIMObject implements SCIMObject {
      *
      * @param lastModifiedDate
      */
+    @Deprecated
     public void setLastModified(Date lastModifiedDate) throws CharonException, BadRequestException {
+        setLastModifiedInstant(lastModifiedDate == null ? null : lastModifiedDate.toInstant());
+    }
+
+    /*
+     * set the last modified date and time of the resource
+     *
+     * @param lastModifiedDate
+     */
+    public void setLastModifiedInstant(Instant lastModified) throws CharonException, BadRequestException {
         //create the lastModified date attribute as defined in schema.
         SimpleAttribute lastModifiedAttribute = (SimpleAttribute) DefaultAttributeFactory.createAttribute(
                 SCIMSchemaDefinitions.LAST_MODIFIED,
-                new SimpleAttribute(SCIMConstants.CommonSchemaConstants.LAST_MODIFIED, lastModifiedDate));
+                new SimpleAttribute(SCIMConstants.CommonSchemaConstants.LAST_MODIFIED, lastModified));
 
         //check meta complex attribute already exist.
         if (getMetaAttribute() != null) {
@@ -407,19 +428,31 @@ public class AbstractSCIMObject implements SCIMObject {
         }
     }
 
+    @Deprecated
     public Date getCreatedDate() throws CharonException {
+        Instant created = getCreatedInstant();
+        return created != null ? new Date(created.toEpochMilli()) : null;
+    }
+
+    public Instant getCreatedInstant() throws CharonException {
         if (this.isMetaAttributeExist()) {
             SimpleAttribute createdDate = (SimpleAttribute) this.getMetaAttribute().getSubAttribute("created");
-            return createdDate != null ? createdDate.getDateValue() : null;
+            return createdDate != null ? createdDate.getInstantValue() : null;
         } else {
             return null;
         }
     }
 
+    @Deprecated
     public Date getLastModified() throws CharonException {
+        Instant lastModified = getLastModifiedInstant();
+        return lastModified != null ? new Date(lastModified.toEpochMilli()) : null;
+    }
+
+    public Instant getLastModifiedInstant() throws CharonException {
         if (this.isMetaAttributeExist()) {
-            SimpleAttribute createdDate = (SimpleAttribute) this.getMetaAttribute().getSubAttribute("lastModified");
-            return createdDate != null ? createdDate.getDateValue() : null;
+            SimpleAttribute lastModified = (SimpleAttribute) this.getMetaAttribute().getSubAttribute("lastModified");
+            return lastModified != null ? lastModified.getInstantValue() : null;
         } else {
             return null;
         }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMConstants.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMConstants.java
@@ -36,8 +36,9 @@ public class SCIMConstants {
     public static final String JSON = "json";
 
     public static final String APPLICATION_JSON = "application/scim+json";
-
+    @Deprecated
     public static final String DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+    @Deprecated
     public static final String DATE_TIME_FORMAT2 = "yyyy-MM-dd'T'HH:mm:ss";
 
     /*Resource names as defined in SCIM Schema spec*/

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/ServerSideValidator.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/ServerSideValidator.java
@@ -15,9 +15,6 @@
  */
 package org.wso2.charon3.core.schema;
 
-import java.time.Instant;
-import java.util.UUID;
-
 import org.wso2.charon3.core.attributes.SimpleAttribute;
 import org.wso2.charon3.core.exceptions.BadRequestException;
 import org.wso2.charon3.core.exceptions.CharonException;
@@ -26,6 +23,9 @@ import org.wso2.charon3.core.objects.AbstractSCIMObject;
 import org.wso2.charon3.core.objects.User;
 import org.wso2.charon3.core.protocol.endpoints.AbstractResourceManager;
 import org.wso2.charon3.core.utils.AttributeUtil;
+
+import java.time.Instant;
+import java.util.UUID;
 
 /**
  * Server Side Validator.

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/ServerSideValidator.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/ServerSideValidator.java
@@ -15,6 +15,9 @@
  */
 package org.wso2.charon3.core.schema;
 
+import java.time.Instant;
+import java.util.UUID;
+
 import org.wso2.charon3.core.attributes.SimpleAttribute;
 import org.wso2.charon3.core.exceptions.BadRequestException;
 import org.wso2.charon3.core.exceptions.CharonException;
@@ -23,9 +26,6 @@ import org.wso2.charon3.core.objects.AbstractSCIMObject;
 import org.wso2.charon3.core.objects.User;
 import org.wso2.charon3.core.protocol.endpoints.AbstractResourceManager;
 import org.wso2.charon3.core.utils.AttributeUtil;
-
-import java.util.Date;
-import java.util.UUID;
 
 /**
  * Server Side Validator.
@@ -53,11 +53,11 @@ public class ServerSideValidator extends AbstractValidator {
         //add created and last modified dates
         String id = UUID.randomUUID().toString();
         scimObject.setId(id);
-        Date date = new Date();
+        Instant now = Instant.now();
         //set the created date and time
-        scimObject.setCreatedDate(AttributeUtil.parseDateTime(AttributeUtil.formatDateTime(date)));
+        scimObject.setCreatedInstant(AttributeUtil.parseDateTime(AttributeUtil.formatDateTime(now)));
         //creates date and the last modified are the same if not updated.
-        scimObject.setLastModified(AttributeUtil.parseDateTime(AttributeUtil.formatDateTime(date)));
+        scimObject.setLastModifiedInstant(AttributeUtil.parseDateTime(AttributeUtil.formatDateTime(now)));
         //set location and resourceType
         if (resourceSchema.isSchemaAvailable(SCIMConstants.USER_CORE_SCHEMA_URI)) {
             String location = createLocationHeader(AbstractResourceManager.getResourceEndpointURL(
@@ -152,8 +152,7 @@ public class ServerSideValidator extends AbstractValidator {
         //copy id attribute to new group object
         validatedObject.setAttribute(oldObject.getAttribute(SCIMConstants.CommonSchemaConstants.ID));
         //edit last modified date
-        Date date = new Date();
-        validatedObject.setLastModified(date);
+        validatedObject.setLastModifiedInstant(Instant.now());
         //check for required attributes.
         validateSCIMObjectForRequiredAttributes(newObject, resourceSchema);
         //check for schema list

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/AttributeUtil.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/AttributeUtil.java
@@ -15,21 +15,20 @@
  */
 package org.wso2.charon3.core.utils;
 
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.Iterator;
+import java.util.List;
+
 import org.json.JSONObject;
 import org.wso2.charon3.core.exceptions.BadRequestException;
 import org.wso2.charon3.core.exceptions.CharonException;
 import org.wso2.charon3.core.protocol.ResponseCodeConstants;
 import org.wso2.charon3.core.schema.AttributeSchema;
 import org.wso2.charon3.core.schema.SCIMAttributeSchema;
-import org.wso2.charon3.core.schema.SCIMConstants;
 import org.wso2.charon3.core.schema.SCIMDefinitions;
 import org.wso2.charon3.core.schema.SCIMResourceTypeSchema;
-
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.List;
 
 /**
  * This class acts as an utility class for attributes.
@@ -104,7 +103,7 @@ public class AttributeUtil {
             case INTEGER:
                 return String.valueOf(attributeValue);
             case DATE_TIME:
-                return formatDateTime((Date) attributeValue);
+                return formatDateTime((Instant) attributeValue);
             case BINARY:
                 return String.valueOf(attributeValue);
             case REFERENCE:
@@ -120,18 +119,12 @@ public class AttributeUtil {
      *
      * @param dateTimeString
      */
-    public static Date parseDateTime(String dateTimeString) throws CharonException {
+    public static Instant parseDateTime(String dateTimeString) throws CharonException {
         try {
-            SimpleDateFormat sdf = new SimpleDateFormat(SCIMConstants.DATE_TIME_FORMAT);
-            return sdf.parse(dateTimeString);
-        } catch (ParseException e) {
-            try {
-                SimpleDateFormat sdf = new SimpleDateFormat(SCIMConstants.DATE_TIME_FORMAT2);
-                return sdf.parse(dateTimeString);
-            } catch (ParseException e1) {
-                throw new CharonException("Error in parsing date time. " +
-                        "Date time should adhere to the format: " + SCIMConstants.DATE_TIME_FORMAT, e1);
-            }
+            return OffsetDateTime.parse(dateTimeString).toInstant();
+        } catch (DateTimeException e) {
+            throw new CharonException("Error in parsing date time. " +
+                    "Date time should adhere to ISO_OFFSET_DATE_TIME format", e);
         }
     }
 
@@ -150,10 +143,8 @@ public class AttributeUtil {
      *
      * @param date
      */
-    public static String formatDateTime(Date date) {
-        SimpleDateFormat sdf = new SimpleDateFormat(SCIMConstants.DATE_TIME_FORMAT);
-        String formattedDate = sdf.format(date);
-        return formattedDate;
+    public static String formatDateTime(Instant instant) {
+        return instant.toString();
     }
 
     /*

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/AttributeUtil.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/AttributeUtil.java
@@ -20,16 +20,12 @@ import org.wso2.charon3.core.exceptions.BadRequestException;
 import org.wso2.charon3.core.exceptions.CharonException;
 import org.wso2.charon3.core.protocol.ResponseCodeConstants;
 import org.wso2.charon3.core.schema.AttributeSchema;
-import org.wso2.charon3.core.schema.SCIMConstants;
 import org.wso2.charon3.core.schema.SCIMDefinitions;
 import org.wso2.charon3.core.schema.SCIMResourceTypeSchema;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.OffsetDateTime;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 


### PR DESCRIPTION
## Purpose
Charon uses java.util.Date internally and has no proper time zone handling. This results in wrong dates beeing encoded. See: https://github.com/wso2/charon/issues/148

## Goals
Migrate from java.util.Date to java.time.Instant and handle time zone properly.

## Approach
Use the new java.time-API.