### PR TITLE
Allow UserManager implementations to throw AbstractCharonException 

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/extensions/UserManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/extensions/UserManager.java
@@ -15,11 +15,7 @@
  */
 package org.wso2.charon3.core.extensions;
 
-import org.wso2.charon3.core.exceptions.BadRequestException;
-import org.wso2.charon3.core.exceptions.CharonException;
-import org.wso2.charon3.core.exceptions.ConflictException;
-import org.wso2.charon3.core.exceptions.NotFoundException;
-import org.wso2.charon3.core.exceptions.NotImplementedException;
+import org.wso2.charon3.core.exceptions.AbstractCharonException;
 import org.wso2.charon3.core.objects.Group;
 import org.wso2.charon3.core.objects.User;
 import org.wso2.charon3.core.utils.codeutils.Node;
@@ -38,73 +34,73 @@ public interface UserManager {
         /***************User Manipulation operations.*******************/
 
     public User createUser(User user, Map<String, Boolean> requiredAttributes)
-            throws CharonException, ConflictException, BadRequestException;
+            throws AbstractCharonException;
 
     public User getUser(String id, Map<String, Boolean> requiredAttributes)
-            throws CharonException, BadRequestException, NotFoundException;
+            throws AbstractCharonException;
 
     public void deleteUser(String userId)
-            throws NotFoundException, CharonException, NotImplementedException, BadRequestException;
+            throws AbstractCharonException;
 
     default List<Object> listUsersWithGET(Node node, int startIndex, int count, String sortBy, String sortOrder,
                                          String domainName, Map<String, Boolean> requiredAttributes)
-            throws CharonException, NotImplementedException, BadRequestException {
+            throws AbstractCharonException {
         return null;
     }
 
     @Deprecated
     default List<Object> listUsersWithGET(Node node, int startIndex, int count, String sortBy, String sortOrder,
                                          Map<String, Boolean> requiredAttributes)
-            throws CharonException, NotImplementedException, BadRequestException {
+            throws AbstractCharonException {
         return listUsersWithGET(node, startIndex, count, sortBy, sortOrder, null, requiredAttributes);
     }
 
     public List<Object> listUsersWithPost(SearchRequest searchRequest, Map<String, Boolean> requiredAttributes)
-            throws CharonException, NotImplementedException, BadRequestException;
+            throws AbstractCharonException;
 
     public User updateUser(User updatedUser, Map<String, Boolean> requiredAttributes)
-            throws NotImplementedException, CharonException, BadRequestException, NotFoundException;
+            throws AbstractCharonException;
 
     public User getMe(String userName, Map<String, Boolean> requiredAttributes)
-            throws CharonException, BadRequestException, NotFoundException;
+            throws AbstractCharonException;
 
     public User createMe(User user, Map<String, Boolean> requiredAttributes)
-            throws CharonException, ConflictException, BadRequestException;
+            throws AbstractCharonException;
 
     public void deleteMe(String userName)
-            throws NotFoundException, CharonException, NotImplementedException, BadRequestException;
+            throws AbstractCharonException;
 
     public User updateMe(User updatedUser, Map<String, Boolean> requiredAttributes)
-            throws NotImplementedException, CharonException, BadRequestException, NotFoundException;
+            throws AbstractCharonException;
 
 
    /* ****************Group manipulation operations.********************/
 
     public Group createGroup(Group group, Map<String, Boolean> requiredAttributes)
-            throws CharonException, ConflictException, NotImplementedException, BadRequestException;
+            throws AbstractCharonException;
 
     public Group getGroup(String id, Map<String, Boolean> requiredAttributes)
-            throws NotImplementedException, BadRequestException, CharonException, NotFoundException;
+            throws AbstractCharonException;
 
     public void deleteGroup(String id)
-            throws NotFoundException, CharonException, NotImplementedException, BadRequestException;
+            throws AbstractCharonException;
 
     default List<Object> listGroupsWithGET(Node node, int startIndex, int count, String sortBy,
                                           String sortOrder, String domainName, Map<String, Boolean> requiredAttributes)
-            throws CharonException, NotImplementedException, BadRequestException {
+            throws AbstractCharonException {
         return null;
     }
 
     @Deprecated
     default List<Object> listGroupsWithGET(Node node, int startIndex, int count, String sortBy,
                                           String sortOrder, Map<String, Boolean> requiredAttributes)
-            throws CharonException, NotImplementedException, BadRequestException {
+            throws AbstractCharonException {
         return listGroupsWithGET(node, startIndex, count, sortBy, sortOrder, null, requiredAttributes);
     }
 
     public Group updateGroup(Group oldGroup, Group newGroup, Map<String, Boolean> requiredAttributes)
-            throws NotImplementedException, BadRequestException, CharonException, NotFoundException;
+            throws AbstractCharonException;
 
     public List<Object> listGroupsWithPost(SearchRequest searchRequest, Map<String, Boolean> requiredAttributes)
-            throws NotImplementedException, BadRequestException, CharonException;;
+            throws AbstractCharonException;
 }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/BulkResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/BulkResourceManager.java
@@ -19,9 +19,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.charon3.core.encoder.JSONDecoder;
 import org.wso2.charon3.core.encoder.JSONEncoder;
-import org.wso2.charon3.core.exceptions.BadRequestException;
-import org.wso2.charon3.core.exceptions.CharonException;
-import org.wso2.charon3.core.exceptions.InternalErrorException;
+import org.wso2.charon3.core.exceptions.AbstractCharonException;
 import org.wso2.charon3.core.extensions.UserManager;
 import org.wso2.charon3.core.objects.bulk.BulkRequestData;
 import org.wso2.charon3.core.objects.bulk.BulkResponseData;
@@ -78,11 +76,7 @@ public class BulkResourceManager extends AbstractResourceManager {
             //create the final response
             return new SCIMResponse(ResponseCodeConstants.CODE_OK, finalEncodedResponse, responseHeaders);
 
-        } catch (CharonException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (InternalErrorException e) {
+        } catch (AbstractCharonException e) {
             return AbstractResourceManager.encodeSCIMException(e);
         }
     }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
@@ -20,12 +20,11 @@ import org.slf4j.LoggerFactory;
 import org.wso2.charon3.core.attributes.Attribute;
 import org.wso2.charon3.core.encoder.JSONDecoder;
 import org.wso2.charon3.core.encoder.JSONEncoder;
+import org.wso2.charon3.core.exceptions.AbstractCharonException;
 import org.wso2.charon3.core.exceptions.BadRequestException;
 import org.wso2.charon3.core.exceptions.CharonException;
-import org.wso2.charon3.core.exceptions.ConflictException;
 import org.wso2.charon3.core.exceptions.InternalErrorException;
 import org.wso2.charon3.core.exceptions.NotFoundException;
-import org.wso2.charon3.core.exceptions.NotImplementedException;
 import org.wso2.charon3.core.extensions.UserManager;
 import org.wso2.charon3.core.objects.Group;
 import org.wso2.charon3.core.objects.ListedResource;
@@ -100,13 +99,7 @@ public class GroupResourceManager extends AbstractResourceManager {
             Map<String, String> httpHeaders = new HashMap<String, String>();
             httpHeaders.put(SCIMConstants.CONTENT_TYPE_HEADER, SCIMConstants.APPLICATION_JSON);
             return new SCIMResponse(ResponseCodeConstants.CODE_OK, encodedGroup, httpHeaders);
-        } catch (NotFoundException e) {
-            return encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return encodeSCIMException(e);
-        } catch (CharonException e) {
-            return encodeSCIMException(e);
-        } catch (NotImplementedException e) {
+        } catch (AbstractCharonException e) {
             return encodeSCIMException(e);
         }
     }
@@ -166,17 +159,7 @@ public class GroupResourceManager extends AbstractResourceManager {
             //put the uri of the Group object in the response header parameter.
             return new SCIMResponse(ResponseCodeConstants.CODE_CREATED, encodedGroup, httpHeaders);
 
-        } catch (InternalErrorException e) {
-            return encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return encodeSCIMException(e);
-        } catch (ConflictException e) {
-            return encodeSCIMException(e);
-        } catch (CharonException e) {
-            return encodeSCIMException(e);
-        } catch (NotFoundException e) {
-            return encodeSCIMException(e);
-        } catch (NotImplementedException e) {
+        } catch (AbstractCharonException e) {
             return encodeSCIMException(e);
         }
     }
@@ -202,15 +185,7 @@ public class GroupResourceManager extends AbstractResourceManager {
                 //throw internal server error.
                 throw new InternalErrorException(error);
             }
-        } catch (InternalErrorException e) {
-            return encodeSCIMException(e);
-        } catch (CharonException e) {
-            return encodeSCIMException(e);
-        } catch (NotFoundException e) {
-            return encodeSCIMException(e);
-        } catch (NotImplementedException e) {
-            return encodeSCIMException(e);
-        } catch (BadRequestException e) {
+        } catch (AbstractCharonException e) {
             return encodeSCIMException(e);
         }
     }
@@ -326,15 +301,7 @@ public class GroupResourceManager extends AbstractResourceManager {
                 //throw internal server error.
                 throw new InternalErrorException(error);
             }
-        } catch (CharonException e) {
-            return encodeSCIMException(e);
-        } catch (NotFoundException e) {
-            return encodeSCIMException(e);
-        } catch (InternalErrorException e) {
-            return encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return encodeSCIMException(e);
-        } catch (NotImplementedException e) {
+        } catch (AbstractCharonException e) {
             return encodeSCIMException(e);
         } catch (IOException e) {
             String error = "Error in tokenization of the input filter";
@@ -425,15 +392,7 @@ public class GroupResourceManager extends AbstractResourceManager {
                 //throw internal server error.
                 throw new InternalErrorException(error);
             }
-        } catch (CharonException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (NotFoundException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (InternalErrorException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (NotImplementedException e) {
+        } catch (AbstractCharonException e) {
             return AbstractResourceManager.encodeSCIMException(e);
         }
     }
@@ -507,15 +466,7 @@ public class GroupResourceManager extends AbstractResourceManager {
             //put the uri of the User object in the response header parameter.
             return new SCIMResponse(ResponseCodeConstants.CODE_OK, encodedGroup, httpHeaders);
 
-        } catch (NotFoundException e) {
-            return encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return encodeSCIMException(e);
-        } catch (CharonException e) {
-            return encodeSCIMException(e);
-        } catch (InternalErrorException e) {
-            return encodeSCIMException(e);
-        } catch (NotImplementedException e) {
+        } catch (AbstractCharonException e) {
             return encodeSCIMException(e);
         }
     }
@@ -628,15 +579,7 @@ public class GroupResourceManager extends AbstractResourceManager {
             //put the URI of the User object in the response header parameter.
             return new SCIMResponse(ResponseCodeConstants.CODE_OK, encodedGroup, httpHeaders);
 
-        } catch (NotFoundException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (NotImplementedException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (CharonException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (InternalErrorException e) {
+        } catch (AbstractCharonException e) {
             return AbstractResourceManager.encodeSCIMException(e);
         } catch (RuntimeException e) {
             CharonException e1 = new CharonException("Error in performing the patch operation on group resource.", e);

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/MeResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/MeResourceManager.java
@@ -18,12 +18,11 @@ package org.wso2.charon3.core.protocol.endpoints;
 
 import org.wso2.charon3.core.encoder.JSONDecoder;
 import org.wso2.charon3.core.encoder.JSONEncoder;
+import org.wso2.charon3.core.exceptions.AbstractCharonException;
 import org.wso2.charon3.core.exceptions.BadRequestException;
 import org.wso2.charon3.core.exceptions.CharonException;
-import org.wso2.charon3.core.exceptions.ConflictException;
 import org.wso2.charon3.core.exceptions.InternalErrorException;
 import org.wso2.charon3.core.exceptions.NotFoundException;
-import org.wso2.charon3.core.exceptions.NotImplementedException;
 import org.wso2.charon3.core.extensions.UserManager;
 import org.wso2.charon3.core.objects.User;
 import org.wso2.charon3.core.protocol.ResponseCodeConstants;
@@ -86,11 +85,7 @@ public class MeResourceManager extends AbstractResourceManager {
                     SCIMConstants.USER_ENDPOINT) + "/" + user.getId());
             return new SCIMResponse(ResponseCodeConstants.CODE_OK, encodedUser, responseHeaders);
 
-        } catch (NotFoundException e) {
-            return encodeSCIMException(e);
-        } catch (CharonException e) {
-            return encodeSCIMException(e);
-        } catch (BadRequestException e) {
+        } catch (AbstractCharonException e) {
             return encodeSCIMException(e);
         }
     }
@@ -153,15 +148,7 @@ public class MeResourceManager extends AbstractResourceManager {
             return new SCIMResponse(ResponseCodeConstants.CODE_CREATED,
                     encodedUser, responseHeaders);
 
-        } catch (CharonException e) {
-            return encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return encodeSCIMException(e);
-        } catch (ConflictException e) {
-            return encodeSCIMException(e);
-        } catch (InternalErrorException e) {
-            return encodeSCIMException(e);
-        } catch (NotFoundException e) {
+        } catch (AbstractCharonException e) {
             return encodeSCIMException(e);
         }
     }
@@ -180,15 +167,7 @@ public class MeResourceManager extends AbstractResourceManager {
                 //throw internal server error.
                 throw new InternalErrorException(error);
             }
-        } catch (NotFoundException e) {
-            return encodeSCIMException(e);
-        } catch (CharonException e) {
-            return encodeSCIMException(e);
-        } catch (InternalErrorException e) {
-            return encodeSCIMException(e);
-        } catch (NotImplementedException e) {
-            return encodeSCIMException(e);
-        } catch (BadRequestException e) {
+        } catch (AbstractCharonException e) {
             return encodeSCIMException(e);
         }
     }
@@ -268,15 +247,7 @@ public class MeResourceManager extends AbstractResourceManager {
             //put the uri of the User object in the response header parameter.
             return new SCIMResponse(ResponseCodeConstants.CODE_OK, encodedUser, httpHeaders);
 
-        } catch (NotFoundException e) {
-            return encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return encodeSCIMException(e);
-        } catch (CharonException e) {
-            return encodeSCIMException(e);
-        } catch (InternalErrorException e) {
-            return encodeSCIMException(e);
-        } catch (NotImplementedException e) {
+        } catch (AbstractCharonException e) {
             return encodeSCIMException(e);
         }
     }
@@ -388,15 +359,7 @@ public class MeResourceManager extends AbstractResourceManager {
             //put the URI of the User object in the response header parameter.
             return new SCIMResponse(ResponseCodeConstants.CODE_OK, encodedUser, httpHeaders);
 
-        } catch (NotFoundException e) {
-            return encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return encodeSCIMException(e);
-        } catch (NotImplementedException e) {
-            return encodeSCIMException(e);
-        } catch (CharonException e) {
-            return encodeSCIMException(e);
-        } catch (InternalErrorException e) {
+        } catch (AbstractCharonException e) {
             return encodeSCIMException(e);
         } catch (RuntimeException e) {
             CharonException e1 = new CharonException("Error in performing the patch operation on user resource.", e);
@@ -417,7 +380,7 @@ public class MeResourceManager extends AbstractResourceManager {
 
             return user.getUserName();
 
-        } catch (BadRequestException | InternalErrorException | CharonException e) {
+        } catch (AbstractCharonException e) {
             throw new CharonException("Error in getting the username from the anonymous request");
         }
     }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/ResourceTypeResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/ResourceTypeResourceManager.java
@@ -21,10 +21,10 @@ import org.wso2.charon3.core.attributes.ComplexAttribute;
 import org.wso2.charon3.core.attributes.MultiValuedAttribute;
 import org.wso2.charon3.core.encoder.JSONDecoder;
 import org.wso2.charon3.core.encoder.JSONEncoder;
+import org.wso2.charon3.core.exceptions.AbstractCharonException;
 import org.wso2.charon3.core.exceptions.BadRequestException;
 import org.wso2.charon3.core.exceptions.CharonException;
 import org.wso2.charon3.core.exceptions.InternalErrorException;
-import org.wso2.charon3.core.exceptions.NotFoundException;
 import org.wso2.charon3.core.extensions.UserManager;
 import org.wso2.charon3.core.objects.AbstractSCIMObject;
 import org.wso2.charon3.core.protocol.ResponseCodeConstants;
@@ -105,13 +105,7 @@ public class ResourceTypeResourceManager extends AbstractResourceManager {
             //put the uri of the resource type object in the response header parameter.
             return new SCIMResponse(ResponseCodeConstants.CODE_OK,
                     encodedObject, responseHeaders);
-        } catch (CharonException e) {
-            return encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return encodeSCIMException(e);
-        } catch (InternalErrorException e) {
-            return encodeSCIMException(e);
-        } catch (NotFoundException e) {
+        } catch (AbstractCharonException e) {
             return encodeSCIMException(e);
         } catch (JSONException e) {
             return null;

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/ServiceProviderConfigResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/ServiceProviderConfigResourceManager.java
@@ -21,10 +21,9 @@ import org.slf4j.LoggerFactory;
 import org.wso2.charon3.core.config.CharonConfiguration;
 import org.wso2.charon3.core.encoder.JSONDecoder;
 import org.wso2.charon3.core.encoder.JSONEncoder;
+import org.wso2.charon3.core.exceptions.AbstractCharonException;
 import org.wso2.charon3.core.exceptions.BadRequestException;
-import org.wso2.charon3.core.exceptions.CharonException;
 import org.wso2.charon3.core.exceptions.InternalErrorException;
-import org.wso2.charon3.core.exceptions.NotFoundException;
 import org.wso2.charon3.core.extensions.UserManager;
 import org.wso2.charon3.core.objects.AbstractSCIMObject;
 import org.wso2.charon3.core.protocol.ResponseCodeConstants;
@@ -97,13 +96,7 @@ public class ServiceProviderConfigResourceManager extends AbstractResourceManage
             //put the uri of the service provider config object in the response header parameter.
             return new SCIMResponse(ResponseCodeConstants.CODE_OK,
                     encodedObject, responseHeaders);
-        } catch (CharonException e) {
-            return encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return encodeSCIMException(e);
-        } catch (InternalErrorException e) {
-            return encodeSCIMException(e);
-        } catch (NotFoundException e) {
+        } catch (AbstractCharonException e) {
             return encodeSCIMException(e);
         } catch (JSONException e) {
             return null;

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/UserResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/UserResourceManager.java
@@ -22,12 +22,11 @@ import org.slf4j.LoggerFactory;
 import org.wso2.charon3.core.attributes.Attribute;
 import org.wso2.charon3.core.encoder.JSONDecoder;
 import org.wso2.charon3.core.encoder.JSONEncoder;
+import org.wso2.charon3.core.exceptions.AbstractCharonException;
 import org.wso2.charon3.core.exceptions.BadRequestException;
 import org.wso2.charon3.core.exceptions.CharonException;
-import org.wso2.charon3.core.exceptions.ConflictException;
 import org.wso2.charon3.core.exceptions.InternalErrorException;
 import org.wso2.charon3.core.exceptions.NotFoundException;
-import org.wso2.charon3.core.exceptions.NotImplementedException;
 import org.wso2.charon3.core.extensions.UserManager;
 import org.wso2.charon3.core.objects.ListedResource;
 import org.wso2.charon3.core.objects.User;
@@ -108,11 +107,7 @@ public class UserResourceManager extends AbstractResourceManager {
                     SCIMConstants.USER_ENDPOINT) + "/" + user.getId());
             return new SCIMResponse(ResponseCodeConstants.CODE_OK, encodedUser, responseHeaders);
 
-        } catch (NotFoundException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (CharonException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (BadRequestException e) {
+        } catch (AbstractCharonException e) {
             return AbstractResourceManager.encodeSCIMException(e);
         }
     }
@@ -187,13 +182,7 @@ public class UserResourceManager extends AbstractResourceManager {
                 e.setStatus(ResponseCodeConstants.CODE_INTERNAL_ERROR);
             }
             return AbstractResourceManager.encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (ConflictException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (InternalErrorException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (NotFoundException e) {
+        } catch (AbstractCharonException e) {
             return AbstractResourceManager.encodeSCIMException(e);
         }
     }
@@ -219,15 +208,7 @@ public class UserResourceManager extends AbstractResourceManager {
                 //throw internal server error.
                 throw new InternalErrorException(error);
             }
-        } catch (NotFoundException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (CharonException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (InternalErrorException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (NotImplementedException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (BadRequestException e) {
+        } catch (AbstractCharonException e) {
             return AbstractResourceManager.encodeSCIMException(e);
         }
     }
@@ -341,15 +322,7 @@ public class UserResourceManager extends AbstractResourceManager {
                 //throw internal server error.
                 throw new InternalErrorException(error);
             }
-        } catch (CharonException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (NotFoundException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (InternalErrorException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (NotImplementedException e) {
+        } catch (AbstractCharonException e) {
             return AbstractResourceManager.encodeSCIMException(e);
         } catch (IOException e) {
             String error = "Error in tokenization of the input filter";
@@ -434,15 +407,7 @@ public class UserResourceManager extends AbstractResourceManager {
                 //throw internal server error.
                 throw new InternalErrorException(error);
             }
-        } catch (CharonException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (NotFoundException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (InternalErrorException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (NotImplementedException e) {
+        } catch (AbstractCharonException e) {
             return AbstractResourceManager.encodeSCIMException(e);
         }
     }
@@ -516,15 +481,7 @@ public class UserResourceManager extends AbstractResourceManager {
             //put the uri of the User object in the response header parameter.
             return new SCIMResponse(ResponseCodeConstants.CODE_OK, encodedUser, httpHeaders);
 
-        } catch (NotFoundException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (CharonException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (InternalErrorException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (NotImplementedException e) {
+        } catch (AbstractCharonException e) {
             return AbstractResourceManager.encodeSCIMException(e);
         }
     }
@@ -635,15 +592,7 @@ public class UserResourceManager extends AbstractResourceManager {
             }
             //put the URI of the User object in the response header parameter.
             return new SCIMResponse(ResponseCodeConstants.CODE_OK, encodedUser, httpHeaders);
-        } catch (NotFoundException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (NotImplementedException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (CharonException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (InternalErrorException e) {
+        } catch (AbstractCharonException e) {
             return AbstractResourceManager.encodeSCIMException(e);
         } catch (RuntimeException e) {
             CharonException e1 = new CharonException("Error in performing the patch operation on user resource.", e);


### PR DESCRIPTION
## Purpose
Implementations of `UserManager` are very limited in throwing exceptions. For example implementations of `UserManager::updateGroup` cannot throw a `ConflictException` when updating the group name to an already existing group name, even though this exception would match best.

## Goals
Let `UserManager` implementations throw any `AbstractCharonException`.

## Approach
Change the interface `UserManager` and handle all `AbstractCharonException`s in provided implementations of `ResourceManager`, e.g. `GroupResourceManager`. 
This change is not backward compatible, due to interface change.

## Release note
Allow `UserManager` implementations to throw more specific exceptions.