### PR TITLE
Fix getting and setting timestamps

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/AbstractSCIMObject.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/AbstractSCIMObject.java
@@ -392,28 +392,10 @@ public class AbstractSCIMObject extends ScimAttributeAware implements SCIMObject
         return created != null ? new Date(created.toEpochMilli()) : null;
     }
 
-    public Instant getCreatedInstant() throws CharonException {
-        if (this.isMetaAttributeExist()) {
-            SimpleAttribute createdDate = (SimpleAttribute) this.getMetaAttribute().getSubAttribute("created");
-            return createdDate != null ? createdDate.getInstantValue() : null;
-        } else {
-            return null;
-        }
-    }
-
     @Deprecated
     public Date getLastModified() throws CharonException {
         Instant lastModified = getLastModifiedInstant();
         return lastModified != null ? new Date(lastModified.toEpochMilli()) : null;
-    }
-
-    public Instant getLastModifiedInstant() throws CharonException {
-        if (this.isMetaAttributeExist()) {
-            SimpleAttribute lastModified = (SimpleAttribute) this.getMetaAttribute().getSubAttribute("lastModified");
-            return lastModified != null ? lastModified.getInstantValue() : null;
-        } else {
-            return null;
-        }
     }
 
     public String toString() {

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/ScimAttributeAware.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/ScimAttributeAware.java
@@ -227,7 +227,8 @@ public abstract class ScimAttributeAware {
         SCIMAttributeSchema metaDefinition = SCIMSchemaDefinitions.META;
         SCIMAttributeSchema lastModifiedDefinition = SCIMSchemaDefinitions.LAST_MODIFIED;
         return getComplexAttribute(metaDefinition).map(meta -> {
-            return getSimpleAttribute(lastModifiedDefinition, meta).map(rethrowFunction(SimpleAttribute::getInstantValue))
+            return getSimpleAttribute(lastModifiedDefinition, meta)
+                    .map(rethrowFunction(SimpleAttribute::getInstantValue))
                     .map(instant -> LocalDateTime
                             .ofInstant(instant, TimeZone.getDefault().toZoneId()))
                     .orElse(null);
@@ -242,7 +243,8 @@ public abstract class ScimAttributeAware {
         SCIMAttributeSchema metaDefinition = SCIMSchemaDefinitions.META;
         SCIMAttributeSchema lastModifiedDefinition = SCIMSchemaDefinitions.LAST_MODIFIED;
         return getComplexAttribute(metaDefinition).map(meta -> {
-            return getSimpleAttribute(lastModifiedDefinition, meta).map(rethrowFunction(SimpleAttribute::getInstantValue))
+            return getSimpleAttribute(lastModifiedDefinition, meta)
+                    .map(rethrowFunction(SimpleAttribute::getInstantValue))
                     .orElse(null);
         }).orElse(null);
     }


### PR DESCRIPTION
the change from java.util.Date to java.tim.Instant created some errors in ScimAttributeAware. This commit will fix the problem by using java.time.Instant