### PR TITLE
Group schema error

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/AbstractSCIMObject.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/AbstractSCIMObject.java
@@ -392,28 +392,10 @@ public class AbstractSCIMObject extends ScimAttributeAware implements SCIMObject
         return created != null ? new Date(created.toEpochMilli()) : null;
     }
 
-    public Instant getCreatedInstant() throws CharonException {
-        if (this.isMetaAttributeExist()) {
-            SimpleAttribute createdDate = (SimpleAttribute) this.getMetaAttribute().getSubAttribute("created");
-            return createdDate != null ? createdDate.getInstantValue() : null;
-        } else {
-            return null;
-        }
-    }
-
     @Deprecated
     public Date getLastModified() throws CharonException {
         Instant lastModified = getLastModifiedInstant();
         return lastModified != null ? new Date(lastModified.toEpochMilli()) : null;
-    }
-
-    public Instant getLastModifiedInstant() throws CharonException {
-        if (this.isMetaAttributeExist()) {
-            SimpleAttribute lastModified = (SimpleAttribute) this.getMetaAttribute().getSubAttribute("lastModified");
-            return lastModified != null ? lastModified.getInstantValue() : null;
-        } else {
-            return null;
-        }
     }
 
     public String toString() {

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/Group.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/Group.java
@@ -32,6 +32,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.wso2.charon3.core.schema.SCIMConstants.CommonSchemaConstants.VALUE;
+import static org.wso2.charon3.core.schema.SCIMConstants.GroupSchemaConstants.MEMBERS;
+
 /**
  * Represents the Group object which is a collection of attributes defined by SCIM Group-schema.
  */
@@ -214,6 +217,65 @@ public class Group extends AbstractSCIMObject {
             setSchema(scheme);
         }
 
+    }
+
+    /**
+     * Returns the ID list of all members of type User
+     */
+    public List<String> getUserIds()
+    {
+        return getMemberIdsOfType(SCIMConstants.USER);
+    }
+
+
+    /**
+     * Returns the ID list of all members of type Group
+     */
+    public List<String> getSubGroupIds()
+    {
+        return getMemberIdsOfType(SCIMConstants.GROUP);
+    }
+
+
+    /**
+     * Returns the ID list of all members of specified type
+     */
+    private List<String> getMemberIdsOfType(String searchType)
+    {
+        List<String> memberIds = new ArrayList<>();
+        if (!isAttributeExist(MEMBERS))
+        {
+            return memberIds;
+        }
+
+        MultiValuedAttribute membersAttribute = (MultiValuedAttribute)getAttribute(MEMBERS);
+        List<Attribute> memberList = membersAttribute.getAttributeValues();
+        for ( Attribute memberListEntry : memberList )
+        {
+            ComplexAttribute memberComplexAttribute = (ComplexAttribute)memberListEntry;
+            if (!memberComplexAttribute.isSubAttributeExist(VALUE)
+                || !memberComplexAttribute.isSubAttributeExist(SCIMConstants.CommonSchemaConstants.TYPE))
+            {
+                continue;
+            }
+            //@formatter:off
+            String type = (String)(LambdaExceptionUtils.rethrowSupplier(() ->
+                (SimpleAttribute)memberComplexAttribute.getSubAttribute(SCIMConstants.CommonSchemaConstants.TYPE))
+                .get()).getValue();
+            //@formatter:on
+            if (type == null || !type.equals(searchType))
+            {
+                continue;
+            }
+
+            //@formatter:off
+            String value = (LambdaExceptionUtils.rethrowSupplier(() ->
+                ((SimpleAttribute)memberComplexAttribute.getSubAttribute(SCIMConstants.CommonSchemaConstants.VALUE))
+                    .getStringValue())).get();
+            //@formatter:on
+            memberIds.add(value);
+        }
+        return memberIds;
     }
 
 }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMSchemaDefinitions.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMSchemaDefinitions.java
@@ -887,7 +887,7 @@ public class SCIMSchemaDefinitions {
                         false, false,
                         SCIMDefinitions.Mutability.READ_WRITE, SCIMDefinitions.Returned.DEFAULT,
                         SCIMDefinitions.Uniqueness.NONE, null, null, new ArrayList<AttributeSchema>(Arrays.asList
-                                (VALUE, REF, DISPLAY)));
+                                (VALUE, REF, DISPLAY, TYPE)));
     }
 
     /**


### PR DESCRIPTION
The group members schema object was missing the TYPE attribute which results in problems when decoding groups because the type cannot be identified.