### PR TITLE
decoding scim exceptions

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/exceptions/AbstractCharonException.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/exceptions/AbstractCharonException.java
@@ -27,19 +27,31 @@ import org.wso2.charon3.core.protocol.ResponseCodeConstants;
  */
 public class AbstractCharonException extends Exception {
 
-    //Error responses are identified using the following "schema" uri
+    /**
+     * Error responses are identified using the following "schema" uri
+     */
     protected String schemas;
 
-    //A detailed human-readable message.
+    /**
+     * A detailed human-readable message.
+     */
     protected String detail;
 
-    //The HTTP status code
+    /**
+     * The HTTP status code
+     */
     protected int status;
+
+    /**
+     * the scim type for scim errors as defined in RFC7644 3.12
+     */
+    protected String scimType;
 
     public AbstractCharonException(int status, String detail, String scimType) {
         this.schemas = ResponseCodeConstants.ERROR_RESPONSE_SCHEMA_URI;
         this.status = status;
         this.detail = detail;
+        this.scimType = scimType;
     }
     public AbstractCharonException() {
         this.schemas = ResponseCodeConstants.ERROR_RESPONSE_SCHEMA_URI;
@@ -89,6 +101,12 @@ public class AbstractCharonException extends Exception {
 
     public void setStatus(int status) {
         this.status = status; }
+
+    public String getScimType() {
+        return scimType; }
+
+    public void setScimType(String scimType) {
+        this.scimType = scimType; }
 }
 
 

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/exceptions/BadRequestException.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/exceptions/BadRequestException.java
@@ -23,25 +23,12 @@ import org.wso2.charon3.core.protocol.ResponseCodeConstants;
  */
 public class BadRequestException extends AbstractCharonException {
 
-    //A SCIM detail error keyword.
-    protected String scimType;
-
     public BadRequestException(String scimType) {
-        status = ResponseCodeConstants.CODE_BAD_REQUEST;
-        detail = ResponseCodeConstants.DESC_BAD_REQUEST;
-        this.scimType = scimType;
+        this(ResponseCodeConstants.DESC_BAD_REQUEST, scimType);
     }
 
     public BadRequestException(String details, String scimType) {
-        status = ResponseCodeConstants.CODE_BAD_REQUEST;
-        this.detail = details;
-        this.scimType = scimType;
+        super(ResponseCodeConstants.CODE_BAD_REQUEST, details, scimType);
     }
-
-    public String getScimType() {
-        return scimType; }
-
-    public void setScimType(String scimType) {
-        this.scimType = scimType; }
 
 }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/exceptions/CharonException.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/exceptions/CharonException.java
@@ -14,11 +14,18 @@
  * limitations under the License.
  */
 package org.wso2.charon3.core.exceptions;
+
+import org.wso2.charon3.core.protocol.ResponseCodeConstants;
+
 /**
  * General exceptions in charon server side. Those that are not returned to client
  * with in the response.
  */
 public class CharonException extends AbstractCharonException {
+
+    public CharonException() {
+        super(ResponseCodeConstants.CODE_INTERNAL_ERROR, ResponseCodeConstants.DESC_INTERNAL_ERROR, null);
+    }
 
     /**
      * Constructs a new exception with the specified detail message and

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/exceptions/ConflictException.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/exceptions/ConflictException.java
@@ -24,12 +24,10 @@ import org.wso2.charon3.core.protocol.ResponseCodeConstants;
 public class ConflictException extends AbstractCharonException {
 
     public ConflictException() {
-        status = ResponseCodeConstants.CODE_CONFLICT;
-        detail = ResponseCodeConstants.DESC_CONFLICT;
+        this(ResponseCodeConstants.DESC_CONFLICT);
     }
 
     public ConflictException(String detail) {
-        status = ResponseCodeConstants.CODE_CONFLICT;
-        this.detail = detail;
+        super(ResponseCodeConstants.CODE_CONFLICT, detail, null);
     }
 }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/exceptions/ForbiddenException.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/exceptions/ForbiddenException.java
@@ -23,12 +23,11 @@ import org.wso2.charon3.core.protocol.ResponseCodeConstants;
 public class ForbiddenException extends AbstractCharonException {
 
     public ForbiddenException() {
-        status = ResponseCodeConstants.CODE_FORBIDDEN;
-        detail = ResponseCodeConstants.DESC_CONFLICT;
+        this(ResponseCodeConstants.DESC_CONFLICT);
     }
 
     public ForbiddenException(String exception) {
-        status = ResponseCodeConstants.CODE_FORBIDDEN;
+        super(ResponseCodeConstants.CODE_FORBIDDEN, exception, null);
         detail = exception;
     }
 

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/exceptions/FormatNotSupportedException.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/exceptions/FormatNotSupportedException.java
@@ -24,13 +24,11 @@ import org.wso2.charon3.core.protocol.ResponseCodeConstants;
 public class FormatNotSupportedException extends AbstractCharonException {
 
     public FormatNotSupportedException() {
-        this.status = ResponseCodeConstants.CODE_FORMAT_NOT_SUPPORTED;
-        this.detail = ResponseCodeConstants.DESC_FORMAT_NOT_SUPPORTED;
+        this(ResponseCodeConstants.DESC_FORMAT_NOT_SUPPORTED);
     }
 
     public FormatNotSupportedException(String detail) {
-        this.status = ResponseCodeConstants.CODE_FORMAT_NOT_SUPPORTED;
-        this.detail = detail;
+        super(ResponseCodeConstants.CODE_FORMAT_NOT_SUPPORTED, detail, null);
     }
 
 }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/exceptions/InternalErrorException.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/exceptions/InternalErrorException.java
@@ -21,9 +21,12 @@ import org.wso2.charon3.core.protocol.ResponseCodeConstants;
  * An internal error.
  */
 public class InternalErrorException extends AbstractCharonException {
+
+    public InternalErrorException() {
+        this(ResponseCodeConstants.DESC_INTERNAL_ERROR);
+    }
+
     public InternalErrorException(String error) {
-        this.schemas = ResponseCodeConstants.ERROR_RESPONSE_SCHEMA_URI;
-        this.status = ResponseCodeConstants.CODE_INTERNAL_ERROR;
-        this.detail = error;
+        super(ResponseCodeConstants.CODE_INTERNAL_ERROR, error, null);
     }
 }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/exceptions/NotFoundException.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/exceptions/NotFoundException.java
@@ -24,12 +24,10 @@ import org.wso2.charon3.core.protocol.ResponseCodeConstants;
 public class NotFoundException extends AbstractCharonException {
 
     public NotFoundException() {
-        status = ResponseCodeConstants.CODE_RESOURCE_NOT_FOUND;
-        detail = ResponseCodeConstants.DESC_RESOURCE_NOT_FOUND;
+        this(ResponseCodeConstants.DESC_RESOURCE_NOT_FOUND);
     }
 
     public NotFoundException(String detail) {
-        status = ResponseCodeConstants.CODE_RESOURCE_NOT_FOUND;
-        this.detail = detail;
+        super(ResponseCodeConstants.CODE_RESOURCE_NOT_FOUND, detail, null);
     }
 }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/exceptions/NotImplementedException.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/exceptions/NotImplementedException.java
@@ -21,8 +21,12 @@ import org.wso2.charon3.core.protocol.ResponseCodeConstants;
  * Service provider does not support the request operation.
  */
 public class NotImplementedException extends AbstractCharonException {
+
+    public NotImplementedException() {
+        this(ResponseCodeConstants.DESC_NOT_IMPLEMENTED);
+    }
+
     public NotImplementedException(String msg) {
-        status = ResponseCodeConstants.CODE_NOT_IMPLEMENTED;
-        detail = msg;
+        super(ResponseCodeConstants.CODE_NOT_IMPLEMENTED, msg, null);
     }
 }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/exceptions/PayloadTooLargeException.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/exceptions/PayloadTooLargeException.java
@@ -22,8 +22,11 @@ import org.wso2.charon3.core.protocol.ResponseCodeConstants;
  */
 public class PayloadTooLargeException extends AbstractCharonException {
 
+    public PayloadTooLargeException() {
+        this(ResponseCodeConstants.DESC_PAYLOAD_TOO_LARGE);
+    }
+
     public PayloadTooLargeException(String msg) {
-        status = ResponseCodeConstants.CODE_PAYLOAD_TOO_LARGE;
-        detail = msg;
+        super(ResponseCodeConstants.CODE_PAYLOAD_TOO_LARGE, msg, null);
     }
 }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/exceptions/PermanentRedirectException.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/exceptions/PermanentRedirectException.java
@@ -22,8 +22,11 @@ import org.wso2.charon3.core.protocol.ResponseCodeConstants;
  */
 public class PermanentRedirectException extends AbstractCharonException {
 
+    public PermanentRedirectException() {
+        this(ResponseCodeConstants.DESC_PERMANENT_REDIRECT);
+    }
+
     public PermanentRedirectException(String msg) {
-        status = ResponseCodeConstants.CODE_PERMANENT_REDIRECT;
-        detail = msg;
+        super(ResponseCodeConstants.CODE_PERMANENT_REDIRECT, msg, null);
     }
 }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/exceptions/PreConditionFailedException.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/exceptions/PreConditionFailedException.java
@@ -24,7 +24,6 @@ import org.wso2.charon3.core.protocol.ResponseCodeConstants;
 public class PreConditionFailedException extends AbstractCharonException {
 
     public PreConditionFailedException() {
-        status = ResponseCodeConstants.CODE_PRECONDITION_FAILED;
-        detail = ResponseCodeConstants.DESC_PRECONDITION_FAILED;
+        super(ResponseCodeConstants.CODE_PRECONDITION_FAILED, ResponseCodeConstants.DESC_PRECONDITION_FAILED, null);
     }
 }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/exceptions/TemporyRedirectException.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/exceptions/TemporyRedirectException.java
@@ -22,8 +22,11 @@ import org.wso2.charon3.core.protocol.ResponseCodeConstants;
  */
 public class TemporyRedirectException extends AbstractCharonException {
 
+    public TemporyRedirectException() {
+        this(ResponseCodeConstants.DESC_TEMPORARY_REDIRECT);
+    }
+
     public TemporyRedirectException(String msg) {
-        status = ResponseCodeConstants.CODE_TEMPORARY_REDIRECT;
-        detail = msg;
+        super(ResponseCodeConstants.CODE_TEMPORARY_REDIRECT, msg, null);
     }
 }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/exceptions/UnauthorizedException.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/exceptions/UnauthorizedException.java
@@ -22,8 +22,11 @@ import org.wso2.charon3.core.protocol.ResponseCodeConstants;
  */
 public class UnauthorizedException extends AbstractCharonException {
 
+    public UnauthorizedException() {
+        this(ResponseCodeConstants.DESC_UNAUTHORIZED);
+    }
+
     public UnauthorizedException(String msg) {
-        status = ResponseCodeConstants.CODE_UNAUTHORIZED;
-        detail = msg;
+        super(ResponseCodeConstants.CODE_UNAUTHORIZED, msg, null);
     }
 }


### PR DESCRIPTION
messed up the previous pull request sorry for that...

for the client side to decode the scim errors to any exception type a specific decoding method was added to the JSONDecoder and all exceptions received a default constructor