### PR TITLE
Add missing "type" attribute to group members

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMSchemaDefinitions.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMSchemaDefinitions.java
@@ -887,7 +887,7 @@ public class SCIMSchemaDefinitions {
                         false, false,
                         SCIMDefinitions.Mutability.READ_WRITE, SCIMDefinitions.Returned.DEFAULT,
                         SCIMDefinitions.Uniqueness.NONE, null, null, new ArrayList<AttributeSchema>(Arrays.asList
-                                (VALUE, REF, DISPLAY)));
+                                (VALUE, REF, DISPLAY, TYPE)));
     }
 
     /**


### PR DESCRIPTION
messed up the previous pull request sorry for that...

the "type" attribute in the members definiton for groups was missing