### PR TITLE
Add support for quoted strings in filter expressions

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/codeutils/FilterTreeManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/codeutils/FilterTreeManager.java
@@ -99,6 +99,8 @@ public class FilterTreeManager {
                     }
                     tokenList.add(input.sval);
                 }
+            } else if (input.ttype == '\"' || input.ttype == '\'') {
+                concatenatedString += " " + input.sval;
             }
         }
         //Add to the list, if the filter is a simple filter


### PR DESCRIPTION
## Purpose
According to charon issues #95 and #116 the filter parser (FilterTreeManager) does not support quoted or doublequoted strings. According to SCIM specification RCF7644, section 3.4.2.2 this is wrong.

## Goals
Handle quotes and doublequotes to conform to specification.