### PR TITLE
Fix decodeToScimException

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONDecoder.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONDecoder.java
@@ -212,7 +212,7 @@ public class JSONDecoder {
         String value = null;
         try {
             JSONArray schemas = jsonObject.getJSONArray(ResponseCodeConstants.SCHEMAS);
-            value = jsonObject.getString(schemas.getString(0));
+            value = schemas.getString(0);
         } catch (JSONException e) {
             logger.debug("could not get '{}' value from scim resource as an array", ResponseCodeConstants.SCHEMAS);
             // if the value could not be extracted as JSONArray we will give it another chance to extract it as

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/exceptions/BadRequestException.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/exceptions/BadRequestException.java
@@ -23,6 +23,10 @@ import org.wso2.charon3.core.protocol.ResponseCodeConstants;
  */
 public class BadRequestException extends AbstractCharonException {
 
+    public BadRequestException() {
+        this("invalid request");
+    }
+
     public BadRequestException(String scimType) {
         this(ResponseCodeConstants.DESC_BAD_REQUEST, scimType);
     }


### PR DESCRIPTION
Accidentally broke the getFirstSchemaValueFromJson method by trying to
extract the schema value from the json value by the value itself
instead by accessing it by index directly...