### PR TITLE
Correct schema URI for Group members

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMConstants.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMConstants.java
@@ -456,7 +456,7 @@ public class SCIMConstants {
         public static final String DISPLAY_NAME = "displayName";
         public static final String DISPLAY_NAME_URI = "urn:ietf:params:scim:schemas:core:2.0:Group:displayName";
         public static final String MEMBERS = "members";
-        public static final String MEMBERS_URI = "urn:ietf:params:scim:schemas:core:2.0:User:members";
+        public static final String MEMBERS_URI = "urn:ietf:params:scim:schemas:core:2.0:Group:members";
         public static final String DISPLAY = "display";
         public static final String TYPE = "type";
 


### PR DESCRIPTION
The schema URI for the attribute "members" of the resource type "Group" is wrong. Possibly due to a copy and paste error. This patch corrects the URI.

Affected version: 3.1.7