### PR TITLE
Handle schemas as common attribute

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONEncoder.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONEncoder.java
@@ -113,9 +113,6 @@ public class JSONEncoder {
         //root json object containing the encoded SCIM Object.
         JSONObject rootObject = new JSONObject();
         try {
-            //encode schemas
-            this.encodeArrayOfValues(SCIMConstants.CommonSchemaConstants.SCHEMAS,
-                    (scimObject.getSchemaList()).toArray(), rootObject);
             //encode attribute list
             Map<String, Attribute> attributes = scimObject.getAttributeList();
             if (attributes != null && !attributes.isEmpty()) {

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/ResourceTypeResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/ResourceTypeResourceManager.java
@@ -188,11 +188,11 @@ public class ResourceTypeResourceManager extends AbstractResourceManager {
         MultiValuedAttribute multiValuedAttribute = new MultiValuedAttribute(
                 SCIMConstants.ListedResourceSchemaConstants.RESOURCES);
 
-        userObject.getSchemaList().clear();
+        userObject.deleteAttribute(SCIMConstants.CommonSchemaConstants.SCHEMAS);
         userObject.setSchema(SCIMConstants.RESOURCE_TYPE_SCHEMA_URI);
         multiValuedAttribute.setAttributePrimitiveValue(userObject);
 
-        groupObject.getSchemaList().clear();
+        groupObject.deleteAttribute(SCIMConstants.CommonSchemaConstants.SCHEMAS);
         groupObject.setSchema(SCIMConstants.RESOURCE_TYPE_SCHEMA_URI);
         multiValuedAttribute.setAttributePrimitiveValue(groupObject);
 

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMConstants.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMConstants.java
@@ -66,6 +66,7 @@ public class SCIMConstants {
     public static class CommonSchemaConstants {
 
         public static final String SCHEMAS = "schemas";
+        public static final String SCHEMAS_URI = "urn:ietf:params:scim:schemas:core:2.0:schemas";
         public static final String ID = "id";
         public static final String ID_URI = "urn:ietf:params:scim:schemas:core:2.0:id";
         public static final String EXTERNAL_ID = "externalId";
@@ -105,6 +106,7 @@ public class SCIMConstants {
                 "were updated at the service provider.";
         public static final String LOCATION_DESC = "Location  The uri of the resource being returned";
         public static final String VERSION_DESC = "The version of the resource being returned.";
+        public static final String SCHEMAS_DESC = "The schemas describing the resource and its attributes";
 
     }
 

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMSchemaDefinitions.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMSchemaDefinitions.java
@@ -34,6 +34,13 @@ public class SCIMSchemaDefinitions {
 
     // sub attributes of the meta attributes
 
+  public static final SCIMAttributeSchema SCHEMAS =
+            SCIMAttributeSchema.createSCIMAttributeSchema(SCIMConstants.CommonSchemaConstants.SCHEMAS_URI,
+                    SCIMConstants.CommonSchemaConstants.SCHEMAS, SCIMDefinitions.DataType.STRING, true,
+                    SCIMConstants.CommonSchemaConstants.SCHEMAS_DESC, false, true,
+                    SCIMDefinitions.Mutability.READ_ONLY, SCIMDefinitions.Returned.DEFAULT,
+                    SCIMDefinitions.Uniqueness.NONE, null, null, null);
+
     //The name of the resource type of the resource.
     public static final SCIMAttributeSchema RESOURCE_TYPE =
             SCIMAttributeSchema.createSCIMAttributeSchema(SCIMConstants.CommonSchemaConstants.RESOURCE_TYPE_URI,


### PR DESCRIPTION
## Purpose
According to the specification the "schemas" attribute is a common attribute so there is no need to handle it separately in class AbstractSCIMObject. Also decoding becomes more simple and straight forward.

## Approach
We added the schemas as a MultiValuedAttribute to the attributeList of AbstractSCIMObject and adapted the setter and getter methods for schemas to work on the attributeList without changing the signatures of these methods.