### PR TITLE
Encoding a ListedResource correctly

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONDecoder.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONDecoder.java
@@ -139,7 +139,6 @@ public class JSONDecoder {
                                                       resourceSchema,
                                                       scimObjectType.newInstance());
                 listedResource.addResource(abstractSCIMObject);
-                listedResource.setResources(abstractSCIMObject.getAttributeList());
             } catch (InternalErrorException | InstantiationException | IllegalAccessException e) {
                 throw new CharonException("could not create resource instance of type " + scimObjectType.getName(), e);
             }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/ListedResource.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/ListedResource.java
@@ -15,14 +15,14 @@
  */
 package org.wso2.charon3.core.objects;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 import org.wso2.charon3.core.attributes.Attribute;
 import org.wso2.charon3.core.attributes.MultiValuedAttribute;
 import org.wso2.charon3.core.attributes.SimpleAttribute;
 import org.wso2.charon3.core.schema.SCIMConstants;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Represents the listed resource object which is a collection of resources.
@@ -136,6 +136,7 @@ public class ListedResource extends AbstractSCIMObject {
      * @param valueWithAttributes
      */
     public void setResources(Map<String, Attribute> valueWithAttributes) {
+        // set given valueWithAttributes as resource in attributeList
         if (!isAttributeExist(SCIMConstants.ListedResourceSchemaConstants.RESOURCES)) {
             MultiValuedAttribute resourcesAttribute =
                 new MultiValuedAttribute(SCIMConstants.ListedResourceSchemaConstants.RESOURCES);
@@ -145,6 +146,10 @@ public class ListedResource extends AbstractSCIMObject {
             ((MultiValuedAttribute) attributeList.get(SCIMConstants.ListedResourceSchemaConstants.RESOURCES))
                 .setComplexValueWithSetOfSubAttributes(valueWithAttributes);
         }
+        // set given valueWithAttributes as resource in list resource
+        AbstractSCIMObject resourcesScimObject = new AbstractSCIMObject();
+        valueWithAttributes.forEach((name, attribtue) -> resourcesScimObject.setAttribute(attribtue));
+        resources.add(resourcesScimObject);
     }
 
     /**
@@ -159,6 +164,15 @@ public class ListedResource extends AbstractSCIMObject {
      * @param scimResourceType the new resource
      */
     public void addResource(SCIMObject scimResourceType) {
+        if (!isAttributeExist(SCIMConstants.ListedResourceSchemaConstants.RESOURCES)) {
+            MultiValuedAttribute resourcesAttribute =
+                new MultiValuedAttribute(SCIMConstants.ListedResourceSchemaConstants.RESOURCES);
+            resourcesAttribute.setComplexValueWithSetOfSubAttributes(scimResourceType.getAttributeList());
+            attributeList.put(SCIMConstants.ListedResourceSchemaConstants.RESOURCES, resourcesAttribute);
+        }else {
+            ((MultiValuedAttribute) attributeList.get(SCIMConstants.ListedResourceSchemaConstants.RESOURCES))
+                .setComplexValueWithSetOfSubAttributes(scimResourceType.getAttributeList());
+        }
         resources.add(scimResourceType);
     }
 }


### PR DESCRIPTION
## Purpose
Currently the resources of a ListedResponse can be added to different locations, the attribute "resources" of ListedResource (through method ListedResource.addResource()) or the "attributeList" of the AbstractSCIMObject (through method ListedResource.setResources()). This can cause missing resources when encoding a ListedResource with the method JSONEncoder.encodeSCIMObject(), because it only includes the resources from the "attribtueList" attribute.

## Approach
We added the given resource in both setter methods to both available locations. This way every approach to get the resources, either ListedResource.getResources() or AbstractSCIMObject.getAttributeList(), still works.