### PR TITLE
Collect and encode schemas

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONEncoder.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONEncoder.java
@@ -33,8 +33,11 @@ import org.wso2.charon3.core.objects.SCIMObject;
 import org.wso2.charon3.core.objects.bulk.BulkResponseContent;
 import org.wso2.charon3.core.objects.bulk.BulkResponseData;
 import org.wso2.charon3.core.protocol.ResponseCodeConstants;
+import org.wso2.charon3.core.schema.AttributeSchema;
+import org.wso2.charon3.core.schema.SCIMAttributeSchema;
 import org.wso2.charon3.core.schema.SCIMConstants;
 import org.wso2.charon3.core.schema.SCIMDefinitions;
+import org.wso2.charon3.core.schema.SCIMDefinitions.ReferenceType;
 import org.wso2.charon3.core.schema.SCIMResourceSchemaManager;
 import org.wso2.charon3.core.utils.AttributeUtil;
 
@@ -43,6 +46,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * This encodes the in the json format.
@@ -503,6 +507,47 @@ public class JSONEncoder {
 
         operationResponseList.add(operationObject);
 
+    }
+
+    /**
+     * Takes a {@link SCIMAttributeSchema} and encodes it to JSON format, then returns it as a String.
+     *
+     * @param attributeSchema the {@link SCIMAttributeSchema} to encode
+     * @return encoded String representation of schema
+     */
+    public String encodeAttributeSchema(SCIMAttributeSchema attributeSchema) {
+        JSONObject rootObject = new JSONObject();
+        try {
+            rootObject.put(SCIMConfigConstants.ATTRIBUTE_URI, attributeSchema.getURI());
+            rootObject.put(SCIMConfigConstants.ATTRIBUTE_NAME, attributeSchema.getName());
+            rootObject.put(SCIMConfigConstants.DATA_TYPE, attributeSchema.getType().toString());
+            rootObject.put(SCIMConfigConstants.MULTIVALUED, String.valueOf(attributeSchema.getMultiValued()));
+            rootObject.put(SCIMConfigConstants.DESCRIPTION, attributeSchema.getDescription());
+            rootObject.put(SCIMConfigConstants.REQUIRED, String.valueOf(attributeSchema.getRequired()));
+            rootObject.put(SCIMConfigConstants.CASE_EXACT, String.valueOf(attributeSchema.getCaseExact()));
+            rootObject.put(SCIMConfigConstants.MUTABILITY, String.valueOf(attributeSchema.getMutability()));
+            rootObject.put(SCIMConfigConstants.RETURNED, attributeSchema.getReturned().toString());
+            rootObject.put(SCIMConfigConstants.UNIQUENESS, attributeSchema.getUniqueness().toString());
+            List<AttributeSchema> subAttributes;
+            if ((subAttributes = attributeSchema.getSubAttributeSchemas()) != null) {
+                List<String> subSchemaUris = subAttributes.stream()
+                                                          .map((schema) -> schema.getURI())
+                                                          .collect(Collectors.toList());
+                rootObject.put(SCIMConfigConstants.SUB_ATTRIBUTES, subSchemaUris);
+            }
+            List<String> canonicalValues;
+            if ((canonicalValues = attributeSchema.getCanonicalValues()) != null) {
+                rootObject.put(SCIMConfigConstants.CANONICAL_VALUES, canonicalValues);
+            }
+            List<ReferenceType> referenceTypes;
+            if ((referenceTypes = attributeSchema.getReferenceTypes()) != null) {
+                rootObject.put(SCIMConfigConstants.REFERENCE_TYPES, referenceTypes);
+            }
+        } catch (JSONException e) {
+            // key should never be null, except method gets called when constants aren't initialized yet.
+            throw new IllegalStateException(e);
+        }
+        return rootObject.toString();
     }
 }
 

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONEncoder.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONEncoder.java
@@ -39,6 +39,7 @@ import org.wso2.charon3.core.schema.SCIMConstants;
 import org.wso2.charon3.core.schema.SCIMDefinitions;
 import org.wso2.charon3.core.schema.SCIMDefinitions.ReferenceType;
 import org.wso2.charon3.core.schema.SCIMResourceSchemaManager;
+import org.wso2.charon3.core.schema.SCIMResourceTypeSchema;
 import org.wso2.charon3.core.utils.AttributeUtil;
 
 import java.time.Instant;
@@ -508,6 +509,30 @@ public class JSONEncoder {
         operationResponseList.add(operationObject);
 
     }
+
+
+    /**
+     * Takes a {@link SCIMResourceTypeSchema} and encodes it to JSON format, then returns it as a String.
+     *
+     * @param resourceSchema the {@link SCIMResourceTypeSchema} to encode
+     * @return encoded String representation of schema
+     */
+    public String encodeResourceTypeSchema(SCIMResourceTypeSchema resourceSchema) {
+        JSONObject rootObject = new JSONObject();
+        JSONArray schemasObject = new JSONArray();
+        resourceSchema.getSchemasList().forEach((schema) -> schemasObject.put(schema));
+        JSONArray attributeObject = new JSONArray();
+        resourceSchema.getAttributesList().forEach(schema -> attributeObject.put(schema.getURI()));
+        try {
+            rootObject.put(SCIMConstants.CommonSchemaConstants.SCHEMAS, schemasObject);
+            rootObject.put(SCIMConstants.OperationalConstants.ATTRIBUTES, attributeObject);
+        } catch (JSONException e) {
+            // key should never be null, except method gets called when constants aren't initialized yet.
+            throw new IllegalStateException(e);
+        }
+        return rootObject.toString();
+    }
+
 
     /**
      * Takes a {@link SCIMAttributeSchema} and encodes it to JSON format, then returns it as a String.

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMAttributeSchema.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMAttributeSchema.java
@@ -21,7 +21,10 @@ import org.wso2.charon3.core.utils.CopyUtil;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * This defines the attributes schema as in SCIM Spec.
@@ -30,6 +33,8 @@ import java.util.List;
 public class SCIMAttributeSchema implements AttributeSchema, Serializable {
 
     private static final long serialVersionUID = 6106269076155338045L;
+
+    private static Map<String, SCIMAttributeSchema> existingSchemas = new HashMap<String, SCIMAttributeSchema>();
     //unique identifier for the attribute
     private String uri;
     //name of the attribute
@@ -77,6 +82,7 @@ public class SCIMAttributeSchema implements AttributeSchema, Serializable {
         this.subAttributes = subAttributes;
         this.canonicalValues = canonicalValues;
         this.referenceTypes = referenceTypes;
+        existingSchemas.put(uri, this);
     }
 
     public static SCIMAttributeSchema createSCIMAttributeSchema(String uri, String name, SCIMDefinitions.DataType type,
@@ -223,5 +229,13 @@ public class SCIMAttributeSchema implements AttributeSchema, Serializable {
 
     public void setReferenceTypes(ArrayList<SCIMDefinitions.ReferenceType> referenceTypes) {
         this.referenceTypes = referenceTypes;
+    }
+
+    public static Set<String> getExistingAttributeSchemaUris() {
+        return existingSchemas.keySet();
+    }
+
+    public static SCIMAttributeSchema getExistingSchema(String uri) {
+        return existingSchemas.get(uri);
     }
 }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMResourceTypeSchema.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMResourceTypeSchema.java
@@ -17,7 +17,10 @@ package org.wso2.charon3.core.schema;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * This declares the SCIM resources schema as specified in SCIM core specification 2.0.
@@ -26,6 +29,9 @@ import java.util.List;
 public class SCIMResourceTypeSchema implements ResourceTypeSchema, Serializable {
 
     private static final long serialVersionUID = 6106269076155338045L;
+
+    private static Map<String, SCIMResourceTypeSchema> existingResourceSchemas
+                                                       = new HashMap<String, SCIMResourceTypeSchema>();
     //The core schema for the resource type is identified using the following schemas URIs
     //e.g.: for 'User' - urn:ietf:params:scim:schemasList:core:2.0:User
     private List<String> schemasList;
@@ -39,6 +45,9 @@ public class SCIMResourceTypeSchema implements ResourceTypeSchema, Serializable 
                 this.attributeList.add(attributeSchema);
             }
         }
+        // assuming that a "ResourceTypeSchema" in most cases only has ONE schema uri,
+        // otherwise it would be considered a resource (which are subclasses of AbstractSCIMObject)
+        existingResourceSchemas.put(schemas.get(0), this);
     }
 
     /*
@@ -82,5 +91,13 @@ public class SCIMResourceTypeSchema implements ResourceTypeSchema, Serializable 
 
     public void setAttributeList(ArrayList attributeList) {
         this.attributeList = attributeList;
+    }
+
+    public static Set<String> getExistingSchemaUris() {
+        return existingResourceSchemas.keySet();
+    }
+
+    public static SCIMResourceTypeSchema getExistingSchema(String uri) {
+        return existingResourceSchemas.get(uri);
     }
 }


### PR DESCRIPTION
## Purpose
In order to make it possible to implement a /Schemas end point as specified in RFC7644 the instantiated schemas have to be available somewhere. Also it's advantageous to be able to get the schemas of resources and their attributes in order to implement a more automated and generic approach of constructing a ResourceType (a resource with the schema uri "urn:ietf:params:scim:schemas:core:2.0:ResourceType") for the /ResourceTypes end point.

## Goals
The SCIMResourceTypeSchemas and SCIMAttributeSchemas are now registered in a static map on creation and they are available through two methods in each class. The JSONEncoder is capable of encoding both types of schemas through two new methods.