### PR TITLE
FIX for ISSUE-177 change data type to boolean for primary attributes

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMSchemaDefinitions.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMSchemaDefinitions.java
@@ -246,7 +246,7 @@ public class SCIMSchemaDefinitions {
         public static final SCIMAttributeSchema IMS_PRIMARY =
                 SCIMAttributeSchema.createSCIMAttributeSchema(SCIMConstants.UserSchemaConstants.IMS_PRIMARY_URI,
                         SCIMConstants.CommonSchemaConstants.PRIMARY,
-                        SCIMDefinitions.DataType.STRING, false, SCIMConstants.UserSchemaConstants.IMS_PRIMARY_DESC,
+                        SCIMDefinitions.DataType.BOOLEAN, false, SCIMConstants.UserSchemaConstants.IMS_PRIMARY_DESC,
                         false, false,
                         SCIMDefinitions.Mutability.READ_WRITE, SCIMDefinitions.Returned.DEFAULT,
                         SCIMDefinitions.Uniqueness.NONE, null, null, null);
@@ -288,7 +288,7 @@ public class SCIMSchemaDefinitions {
         public static final SCIMAttributeSchema PHOTOS_PRIMARY =
                 SCIMAttributeSchema.createSCIMAttributeSchema(SCIMConstants.UserSchemaConstants.PHOTOS_PRIMARY_URI,
                         SCIMConstants.CommonSchemaConstants.PRIMARY,
-                        SCIMDefinitions.DataType.STRING, false, SCIMConstants.UserSchemaConstants
+                        SCIMDefinitions.DataType.BOOLEAN, false, SCIMConstants.UserSchemaConstants
                                 .PHOTOS_PRIMARY_DESC, false, false,
                         SCIMDefinitions.Mutability.READ_WRITE, SCIMDefinitions.Returned.DEFAULT,
                         SCIMDefinitions.Uniqueness.NONE, null, null, null);
@@ -451,7 +451,7 @@ public class SCIMSchemaDefinitions {
                 SCIMAttributeSchema.createSCIMAttributeSchema(SCIMConstants.UserSchemaConstants
                                 .ENTITLEMENTS_PRIMARY_URI,
                         SCIMConstants.CommonSchemaConstants.PRIMARY,
-                        SCIMDefinitions.DataType.STRING, false, SCIMConstants.UserSchemaConstants
+                        SCIMDefinitions.DataType.BOOLEAN, false, SCIMConstants.UserSchemaConstants
                                 .ENTITLEMENTS_PRIMARY_DESC, false, false,
                         SCIMDefinitions.Mutability.READ_WRITE, SCIMDefinitions.Returned.DEFAULT,
                         SCIMDefinitions.Uniqueness.NONE, null, null, null);
@@ -489,7 +489,7 @@ public class SCIMSchemaDefinitions {
         public static final SCIMAttributeSchema ROLES_PRIMARY =
                 SCIMAttributeSchema.createSCIMAttributeSchema(SCIMConstants.UserSchemaConstants.ROLES_PRIMARY_URI,
                         SCIMConstants.CommonSchemaConstants.PRIMARY,
-                        SCIMDefinitions.DataType.STRING, false, SCIMConstants.UserSchemaConstants.ROLES_PRIMARY_DESC,
+                        SCIMDefinitions.DataType.BOOLEAN, false, SCIMConstants.UserSchemaConstants.ROLES_PRIMARY_DESC,
                         false, false,
                         SCIMDefinitions.Mutability.READ_WRITE, SCIMDefinitions.Returned.DEFAULT,
                         SCIMDefinitions.Uniqueness.NONE, null, null, null);
@@ -531,7 +531,7 @@ public class SCIMSchemaDefinitions {
                 SCIMAttributeSchema.createSCIMAttributeSchema(SCIMConstants.UserSchemaConstants
                                 .X509CERTIFICATES_PRIMARY_URI,
                         SCIMConstants.CommonSchemaConstants.PRIMARY,
-                        SCIMDefinitions.DataType.STRING, false, SCIMConstants.UserSchemaConstants
+                        SCIMDefinitions.DataType.BOOLEAN, false, SCIMConstants.UserSchemaConstants
                                 .X509CERTIFICATES_PRIMARY_DESC, false, false,
                         SCIMDefinitions.Mutability.READ_WRITE, SCIMDefinitions.Returned.DEFAULT,
                         SCIMDefinitions.Uniqueness.NONE, null, null, null);


### PR DESCRIPTION
## Purpose
Fix issue related to https://github.com/wso2/charon/issues/177

## User stories
https://github.com/wso2/charon/issues/177

## Release note
SCIMSchemaDefinitions uses wrong type String for PRIMARY sub-attribute. Should be Boolean