### PR TITLE
Handle extension schema attributes

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONDecoder.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONDecoder.java
@@ -54,6 +54,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.wso2.charon3.core.schema.SCIMDefinitions.DataType.BINARY;
 import static org.wso2.charon3.core.schema.SCIMDefinitions.DataType.BOOLEAN;
@@ -291,6 +292,17 @@ public class JSONDecoder {
                 if (attributeValObj == null) {
                     //user may define the attribute by its fully qualified uri
                     attributeValObj = decodedJsonObj.opt(attributeSchema.getURI());
+                }
+                if (attributeValObj == null) {
+                    // user shall define extension attributes in extension namespace, see RFC 7643 figure 5
+                    Optional<String> schemaUri = resourceSchema.getSchemasList().stream()
+                        .filter(attributeSchema.getURI()::startsWith).findFirst();
+                    if (schemaUri.isPresent()) {
+                        Object schemaObject = decodedJsonObj.opt(schemaUri.get());
+                        if (schemaObject instanceof JSONObject) {
+                            attributeValObj = ((JSONObject) schemaObject).opt(attributeSchema.getName());
+                        }
+                    }
                 }
                 SCIMDefinitions.DataType attributeSchemaDataType = attributeSchema.getType();
 


### PR DESCRIPTION
The SCIM specification RFC 7643, chapter 3.3 states:
"Except for the base object schema, the schema extension URI SHALL be used as a
JSON container to distinguish attributes belonging to the extension namespace
from base schema attributes."
An example is given in RFC 7643 figure 5, showing how to properly encode the
attributes belonging to the enterprise user schema extension.

The JSONEncoder now encodes attributes belonging to extension schemas to this
JSON container. The  JSONDecoder is able to handle those JSON container, but
provides backward compatibility.

This addresses the issue #182.
