### PR TITLE
Remove redundant throws

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/attributes/ComplexAttribute.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/attributes/ComplexAttribute.java
@@ -58,7 +58,7 @@ public class ComplexAttribute extends AbstractAttribute {
      * @param attributeName
      * @return Attribute
      */
-    public Attribute getSubAttribute(String attributeName) throws CharonException {
+    public Attribute getSubAttribute(String attributeName) {
         if (subAttributesList.containsKey(attributeName)) {
             return subAttributesList.get(attributeName);
         } else {
@@ -71,7 +71,7 @@ public class ComplexAttribute extends AbstractAttribute {
      * @throws CharonException
      */
     @Override
-    public void deleteSubAttributes() throws CharonException {
+    public void deleteSubAttributes() {
         subAttributesList.clear();
     }
 
@@ -101,8 +101,7 @@ public class ComplexAttribute extends AbstractAttribute {
      * @param subAttribute
      * @throws CharonException
      */
-    public void setSubAttribute(Attribute subAttribute)
-            throws CharonException {
+    public void setSubAttribute(Attribute subAttribute) {
         subAttributesList.put(subAttribute.getName(), subAttribute);
     }
     }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/attributes/DefaultAttributeFactory.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/attributes/DefaultAttributeFactory.java
@@ -16,7 +16,6 @@
 package org.wso2.charon3.core.attributes;
 
 import org.wso2.charon3.core.exceptions.BadRequestException;
-import org.wso2.charon3.core.exceptions.CharonException;
 import org.wso2.charon3.core.protocol.ResponseCodeConstants;
 import org.wso2.charon3.core.schema.AttributeSchema;
 import org.wso2.charon3.core.schema.SCIMDefinitions;
@@ -36,7 +35,7 @@ public class DefaultAttributeFactory {
      * @return Attribute
      */
     public static Attribute createAttribute(AttributeSchema attributeSchema,
-                                            AbstractAttribute attribute) throws CharonException, BadRequestException {
+                                            AbstractAttribute attribute) throws BadRequestException {
 
         attribute.setMutability(attributeSchema.getMutability());
         attribute.setRequired(attributeSchema.getRequired());
@@ -56,9 +55,6 @@ public class DefaultAttributeFactory {
                 attribute.setType(attributeSchema.getType());
             }
             return attribute;
-        } catch (CharonException e) {
-            String error = "Unknown attribute schema.";
-            throw new CharonException(error);
         } catch (BadRequestException e) {
             String error = "Violation in attribute schema. DataType doesn't match that of the value.";
             throw new BadRequestException(error, ResponseCodeConstants.INVALID_VALUE);
@@ -72,12 +68,11 @@ public class DefaultAttributeFactory {
      * @param attributeSchema
      * @param simpleAttribute
      * @return SimpleAttribute
-     * @throws CharonException
      * @throws BadRequestException
      */
     protected static SimpleAttribute createSimpleAttribute
                     (AttributeSchema attributeSchema, SimpleAttribute simpleAttribute)
-            throws CharonException, BadRequestException {
+            throws BadRequestException {
         if (simpleAttribute.getValue() != null) {
             if (isAttributeDataTypeValid(simpleAttribute.getValue(), attributeSchema.getType())) {
                 simpleAttribute.setType(attributeSchema.getType());

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/attributes/MultiValuedAttribute.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/attributes/MultiValuedAttribute.java
@@ -67,7 +67,7 @@ public class MultiValuedAttribute extends AbstractAttribute {
      * @throws CharonException
      */
     @Override
-    public void deleteSubAttributes() throws CharonException {
+    public void deleteSubAttributes() {
         //here we delete the complex type sub attributes which act as sub values
         attributeValues.clear();
     }
@@ -77,7 +77,7 @@ public class MultiValuedAttribute extends AbstractAttribute {
      * @throws CharonException
      */
 
-    public void deletePrimitiveValues() throws CharonException {
+    public void deletePrimitiveValues() {
         //here we delete primitive values
         attributePrimitiveValues.clear();
     }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/attributes/SimpleAttribute.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/attributes/SimpleAttribute.java
@@ -128,7 +128,7 @@ public class SimpleAttribute extends AbstractAttribute {
      * 
      * @throws CharonException
      */
-    public void updateValue(Object value) throws CharonException {
+    public void updateValue(Object value) {
         this.value = value;
     }
 }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONDecoder.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONDecoder.java
@@ -233,7 +233,7 @@ public class JSONDecoder {
      * @return the int value of the key
      * @throws CharonException if the value under the given key is not an int value
      */
-    private String getStringValueFromJson(JSONObject jsonObject, String name) throws CharonException {
+    private String getStringValueFromJson(JSONObject jsonObject, String name) {
         String value = null;
         try {
             value = jsonObject.getString(name);

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/AbstractSCIMObject.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/AbstractSCIMObject.java
@@ -130,8 +130,7 @@ public class AbstractSCIMObject extends ScimAttributeAware implements SCIMObject
      * @param parentAttribute
      * @param childAttribute
      */
-    public void deleteSubSubAttribute(String childAttribute, String parentAttribute, String grandParentAttribute)
-            throws CharonException {
+    public void deleteSubSubAttribute(String childAttribute, String parentAttribute, String grandParentAttribute) {
         if (attributeList.containsKey(grandParentAttribute)) {
             ComplexAttribute grandParent = (ComplexAttribute) attributeList.get(grandParentAttribute);
             Attribute parent = ((ComplexAttribute) grandParent).getSubAttribute(parentAttribute);
@@ -209,7 +208,7 @@ public class AbstractSCIMObject extends ScimAttributeAware implements SCIMObject
      * @param externalId identifier for the SCIM Resource as defined by the provisioning client.
      * @throws BadRequestException
      */
-    public void setExternalId(String externalId) throws CharonException, BadRequestException {
+    public void setExternalId(String externalId) throws BadRequestException {
         SimpleAttribute externalIdAttribute = new SimpleAttribute(
                 SCIMConstants.CommonSchemaConstants.EXTERNAL_ID, externalId);
         DefaultAttributeFactory.createAttribute(SCIMSchemaDefinitions.EXTERNAL_ID, externalIdAttribute);
@@ -387,13 +386,13 @@ public class AbstractSCIMObject extends ScimAttributeAware implements SCIMObject
     }
 
     @Deprecated
-    public Date getCreatedDate() throws CharonException {
+    public Date getCreatedDate() {
         Instant created = getCreatedInstant();
         return created != null ? new Date(created.toEpochMilli()) : null;
     }
 
     @Deprecated
-    public Date getLastModified() throws CharonException {
+    public Date getLastModified() {
         Instant lastModified = getLastModifiedInstant();
         return lastModified != null ? new Date(lastModified.toEpochMilli()) : null;
     }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/Group.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/Group.java
@@ -59,10 +59,9 @@ public class Group extends AbstractSCIMObject {
     /**
      * set the display name of the group
      * @param displayName
-     * @throws CharonException
      * @throws BadRequestException
      */
-    public void setDisplayName(String displayName) throws CharonException, BadRequestException {
+    public void setDisplayName(String displayName) throws BadRequestException {
         if (this.isAttributeExist(SCIMConstants.GroupSchemaConstants.DISPLAY_NAME)) {
             ((SimpleAttribute) this.attributeList.get(SCIMConstants.GroupSchemaConstants.DISPLAY_NAME)).
                     updateValue(displayName);
@@ -141,9 +140,8 @@ public class Group extends AbstractSCIMObject {
      * @param value
      * @param display
      * @throws BadRequestException
-     * @throws CharonException
      */
-    public void setMember(String value, String display) throws BadRequestException, CharonException {
+    public void setMember(String value, String display) throws BadRequestException {
         setMember(value, display, null, null);
     }
 
@@ -157,7 +155,7 @@ public class Group extends AbstractSCIMObject {
      * @throws CharonException
      */
     public void setMember(String value, String display, String ref, String type)
-           throws BadRequestException, CharonException {
+           throws BadRequestException {
         if (!isAttributeExist(SCIMConstants.GroupSchemaConstants.MEMBERS)) {
           MultiValuedAttribute members = new MultiValuedAttribute(SCIMConstants.GroupSchemaConstants.MEMBERS);
           DefaultAttributeFactory.createAttribute(SCIMSchemaDefinitions.SCIMGroupSchemaDefinition.MEMBERS, members);
@@ -174,10 +172,9 @@ public class Group extends AbstractSCIMObject {
      * @param userName
      * @return
      * @throws BadRequestException
-     * @throws CharonException
      */
     private ComplexAttribute setMemberCommon(String userId, String userName, String ref, String type)
-            throws BadRequestException, CharonException {
+            throws BadRequestException {
         ComplexAttribute complexAttribute = new ComplexAttribute();
         complexAttribute.setName(SCIMConstants.GroupSchemaConstants.MEMBERS + "_" + userId + SCIMConstants.DEFAULT);
         SimpleAttribute valueSimpleAttribute = new SimpleAttribute(SCIMConstants.CommonSchemaConstants.VALUE, userId);

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/SCIMObject.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/SCIMObject.java
@@ -16,7 +16,6 @@
 package org.wso2.charon3.core.objects;
 
 import org.wso2.charon3.core.attributes.Attribute;
-import org.wso2.charon3.core.exceptions.NotFoundException;
 
 import java.io.Serializable;
 import java.util.List;
@@ -30,9 +29,9 @@ import java.util.Map;
 //SCIMObject is extended from Serializable as later in org.wso2.charon.core.util.CopyUtil, it need to be serialized.
 public interface SCIMObject extends Serializable {
 
-    public Attribute getAttribute(String attributeName) throws NotFoundException;
+    public Attribute getAttribute(String attributeName);
 
-    public void deleteAttribute(String attributeName) throws NotFoundException;
+    public void deleteAttribute(String attributeName);
 
     public List<String> getSchemaList();
 

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/User.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/User.java
@@ -631,7 +631,7 @@ public class User extends AbstractSCIMObject {
      * @throws CharonException
      * @throws BadRequestException
      */
-    public void setUserName(String userName) throws CharonException, BadRequestException {
+    public void setUserName(String userName) throws BadRequestException {
 
         this.setSimpleAttribute(SCIMConstants.UserSchemaConstants.USER_NAME,
                 SCIMSchemaDefinitions.SCIMUserSchemaDefinition.USERNAME, userName);
@@ -665,7 +665,7 @@ public class User extends AbstractSCIMObject {
      * @throws CharonException
      * @throws BadRequestException
      */
-    public void setPassword(String password) throws CharonException, BadRequestException {
+    public void setPassword(String password) throws BadRequestException {
 
         setSimpleAttribute(SCIMConstants.UserSchemaConstants.PASSWORD, SCIMSchemaDefinitions.SCIMUserSchemaDefinition.
                 PASSWORD, password);
@@ -677,12 +677,11 @@ public class User extends AbstractSCIMObject {
      * @param attributeName
      * @param attributeSchema
      * @param value
-     * @throws CharonException
      * @throws BadRequestException
      */
     private void setSimpleAttribute(String attributeName,
                                     AttributeSchema attributeSchema,
-                                    Object value) throws CharonException, BadRequestException {
+                                    Object value) throws BadRequestException {
 
         if (this.isAttributeExist(attributeName)) {
             ((SimpleAttribute) this.attributeList.get(attributeName)).updateValue(value);
@@ -720,7 +719,7 @@ public class User extends AbstractSCIMObject {
      */
     public void setGroup(String type,
                          String value,
-                         String display) throws CharonException, BadRequestException {
+                         String display) throws BadRequestException {
 
         SimpleAttribute typeSimpleAttribute = null;
         SimpleAttribute valueSimpleAttribute = null;
@@ -764,7 +763,7 @@ public class User extends AbstractSCIMObject {
         }
     }
 
-    private void setGroup(ComplexAttribute groupPropertiesAttribute) throws CharonException, BadRequestException {
+    private void setGroup(ComplexAttribute groupPropertiesAttribute) throws BadRequestException {
 
         MultiValuedAttribute groupsAttribute;
 

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/AbstractResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/AbstractResourceManager.java
@@ -20,7 +20,6 @@ import org.slf4j.LoggerFactory;
 import org.wso2.charon3.core.encoder.JSONDecoder;
 import org.wso2.charon3.core.encoder.JSONEncoder;
 import org.wso2.charon3.core.exceptions.AbstractCharonException;
-import org.wso2.charon3.core.exceptions.CharonException;
 import org.wso2.charon3.core.exceptions.NotFoundException;
 import org.wso2.charon3.core.protocol.SCIMResponse;
 import org.wso2.charon3.core.schema.SCIMConstants;
@@ -49,7 +48,7 @@ public abstract class AbstractResourceManager implements ResourceManager {
      * @return JSONEncoder - An json encoder for encoding data
      * @throws CharonException
      */
-    public static JSONEncoder getEncoder() throws CharonException {
+    public static JSONEncoder getEncoder() {
         return encoder;
     }
 
@@ -60,7 +59,7 @@ public abstract class AbstractResourceManager implements ResourceManager {
      * @return JSONDecoder - An json decoder for decoding data
      * @throws CharonException
      */
-    public static JSONDecoder getDecoder() throws CharonException {
+    public static JSONDecoder getDecoder() {
         return decoder;
     }
 

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/BulkResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/BulkResourceManager.java
@@ -19,9 +19,8 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.charon3.core.encoder.JSONDecoder;
 import org.wso2.charon3.core.encoder.JSONEncoder;
-import org.wso2.charon3.core.exceptions.BadRequestException;
+import org.wso2.charon3.core.exceptions.AbstractCharonException;
 import org.wso2.charon3.core.exceptions.CharonException;
-import org.wso2.charon3.core.exceptions.InternalErrorException;
 import org.wso2.charon3.core.extensions.UserManager;
 import org.wso2.charon3.core.objects.bulk.BulkRequestData;
 import org.wso2.charon3.core.objects.bulk.BulkResponseData;
@@ -78,12 +77,10 @@ public class BulkResourceManager extends AbstractResourceManager {
             //create the final response
             return new SCIMResponse(ResponseCodeConstants.CODE_OK, finalEncodedResponse, responseHeaders);
 
-        } catch (CharonException e) {
+        } catch (AbstractCharonException e) {
             return AbstractResourceManager.encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (InternalErrorException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
+        } catch (Exception ex) {
+            return AbstractResourceManager.encodeSCIMException(new CharonException(ex.getMessage(), ex));
         }
     }
 

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
@@ -607,8 +607,7 @@ public class GroupResourceManager extends AbstractResourceManager {
      * @param groups
      * @return
      */
-    public ListedResource createListedResource(List<Object> groups, int startIndex, int totalResults)
-            throws CharonException, NotFoundException {
+    public ListedResource createListedResource(List<Object> groups, int startIndex, int totalResults) {
         ListedResource listedResource = new ListedResource();
         listedResource.setSchema(SCIMConstants.LISTED_RESOURCE_CORE_SCHEMA_URI);
         listedResource.setTotalResults(totalResults);

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
@@ -20,12 +20,11 @@ import org.slf4j.LoggerFactory;
 import org.wso2.charon3.core.attributes.Attribute;
 import org.wso2.charon3.core.encoder.JSONDecoder;
 import org.wso2.charon3.core.encoder.JSONEncoder;
+import org.wso2.charon3.core.exceptions.AbstractCharonException;
 import org.wso2.charon3.core.exceptions.BadRequestException;
 import org.wso2.charon3.core.exceptions.CharonException;
-import org.wso2.charon3.core.exceptions.ConflictException;
 import org.wso2.charon3.core.exceptions.InternalErrorException;
 import org.wso2.charon3.core.exceptions.NotFoundException;
-import org.wso2.charon3.core.exceptions.NotImplementedException;
 import org.wso2.charon3.core.extensions.UserManager;
 import org.wso2.charon3.core.objects.Group;
 import org.wso2.charon3.core.objects.ListedResource;
@@ -100,14 +99,10 @@ public class GroupResourceManager extends AbstractResourceManager {
             Map<String, String> httpHeaders = new HashMap<String, String>();
             httpHeaders.put(SCIMConstants.CONTENT_TYPE_HEADER, SCIMConstants.APPLICATION_JSON);
             return new SCIMResponse(ResponseCodeConstants.CODE_OK, encodedGroup, httpHeaders);
-        } catch (NotFoundException e) {
+        } catch (AbstractCharonException e) {
             return encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return encodeSCIMException(e);
-        } catch (CharonException e) {
-            return encodeSCIMException(e);
-        } catch (NotImplementedException e) {
-            return encodeSCIMException(e);
+        } catch (Exception ex) {
+            return AbstractResourceManager.encodeSCIMException(new CharonException(ex.getMessage(), ex));
         }
     }
 
@@ -166,18 +161,10 @@ public class GroupResourceManager extends AbstractResourceManager {
             //put the uri of the Group object in the response header parameter.
             return new SCIMResponse(ResponseCodeConstants.CODE_CREATED, encodedGroup, httpHeaders);
 
-        } catch (InternalErrorException e) {
+        } catch (AbstractCharonException e) {
             return encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return encodeSCIMException(e);
-        } catch (ConflictException e) {
-            return encodeSCIMException(e);
-        } catch (CharonException e) {
-            return encodeSCIMException(e);
-        } catch (NotFoundException e) {
-            return encodeSCIMException(e);
-        } catch (NotImplementedException e) {
-            return encodeSCIMException(e);
+        } catch (Exception ex) {
+            return AbstractResourceManager.encodeSCIMException(new CharonException(ex.getMessage(), ex));
         }
     }
 
@@ -202,16 +189,10 @@ public class GroupResourceManager extends AbstractResourceManager {
                 //throw internal server error.
                 throw new InternalErrorException(error);
             }
-        } catch (InternalErrorException e) {
+        } catch (AbstractCharonException e) {
             return encodeSCIMException(e);
-        } catch (CharonException e) {
-            return encodeSCIMException(e);
-        } catch (NotFoundException e) {
-            return encodeSCIMException(e);
-        } catch (NotImplementedException e) {
-            return encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return encodeSCIMException(e);
+        } catch (Exception ex) {
+            return AbstractResourceManager.encodeSCIMException(new CharonException(ex.getMessage(), ex));
         }
     }
 
@@ -326,20 +307,14 @@ public class GroupResourceManager extends AbstractResourceManager {
                 //throw internal server error.
                 throw new InternalErrorException(error);
             }
-        } catch (CharonException e) {
-            return encodeSCIMException(e);
-        } catch (NotFoundException e) {
-            return encodeSCIMException(e);
-        } catch (InternalErrorException e) {
-            return encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return encodeSCIMException(e);
-        } catch (NotImplementedException e) {
+        } catch (AbstractCharonException e) {
             return encodeSCIMException(e);
         } catch (IOException e) {
             String error = "Error in tokenization of the input filter";
             CharonException charonException = new CharonException(error);
             return AbstractResourceManager.encodeSCIMException(charonException);
+        } catch (Exception ex) {
+            return AbstractResourceManager.encodeSCIMException(new CharonException(ex.getMessage(), ex));
         }
     }
 
@@ -425,16 +400,10 @@ public class GroupResourceManager extends AbstractResourceManager {
                 //throw internal server error.
                 throw new InternalErrorException(error);
             }
-        } catch (CharonException e) {
+        } catch (AbstractCharonException e) {
             return AbstractResourceManager.encodeSCIMException(e);
-        } catch (NotFoundException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (InternalErrorException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (NotImplementedException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
+        } catch (Exception ex) {
+            return AbstractResourceManager.encodeSCIMException(new CharonException(ex.getMessage(), ex));
         }
     }
 
@@ -507,16 +476,10 @@ public class GroupResourceManager extends AbstractResourceManager {
             //put the uri of the User object in the response header parameter.
             return new SCIMResponse(ResponseCodeConstants.CODE_OK, encodedGroup, httpHeaders);
 
-        } catch (NotFoundException e) {
+        } catch (AbstractCharonException e) {
             return encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return encodeSCIMException(e);
-        } catch (CharonException e) {
-            return encodeSCIMException(e);
-        } catch (InternalErrorException e) {
-            return encodeSCIMException(e);
-        } catch (NotImplementedException e) {
-            return encodeSCIMException(e);
+        } catch (Exception ex) {
+            return AbstractResourceManager.encodeSCIMException(new CharonException(ex.getMessage(), ex));
         }
     }
 
@@ -628,19 +591,13 @@ public class GroupResourceManager extends AbstractResourceManager {
             //put the URI of the User object in the response header parameter.
             return new SCIMResponse(ResponseCodeConstants.CODE_OK, encodedGroup, httpHeaders);
 
-        } catch (NotFoundException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (NotImplementedException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (CharonException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (InternalErrorException e) {
+        } catch (AbstractCharonException e) {
             return AbstractResourceManager.encodeSCIMException(e);
         } catch (RuntimeException e) {
             CharonException e1 = new CharonException("Error in performing the patch operation on group resource.", e);
             return AbstractResourceManager.encodeSCIMException(e1);
+        } catch (Exception ex) {
+            return AbstractResourceManager.encodeSCIMException(new CharonException(ex.getMessage(), ex));
         }
     }
 

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/MeResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/MeResourceManager.java
@@ -18,12 +18,11 @@ package org.wso2.charon3.core.protocol.endpoints;
 
 import org.wso2.charon3.core.encoder.JSONDecoder;
 import org.wso2.charon3.core.encoder.JSONEncoder;
+import org.wso2.charon3.core.exceptions.AbstractCharonException;
 import org.wso2.charon3.core.exceptions.BadRequestException;
 import org.wso2.charon3.core.exceptions.CharonException;
-import org.wso2.charon3.core.exceptions.ConflictException;
 import org.wso2.charon3.core.exceptions.InternalErrorException;
 import org.wso2.charon3.core.exceptions.NotFoundException;
-import org.wso2.charon3.core.exceptions.NotImplementedException;
 import org.wso2.charon3.core.extensions.UserManager;
 import org.wso2.charon3.core.objects.User;
 import org.wso2.charon3.core.protocol.ResponseCodeConstants;
@@ -86,12 +85,10 @@ public class MeResourceManager extends AbstractResourceManager {
                     SCIMConstants.USER_ENDPOINT) + "/" + user.getId());
             return new SCIMResponse(ResponseCodeConstants.CODE_OK, encodedUser, responseHeaders);
 
-        } catch (NotFoundException e) {
+        } catch (AbstractCharonException e) {
             return encodeSCIMException(e);
-        } catch (CharonException e) {
-            return encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return encodeSCIMException(e);
+        } catch (Exception ex) {
+            return AbstractResourceManager.encodeSCIMException(new CharonException(ex.getMessage(), ex));
         }
     }
 
@@ -153,16 +150,10 @@ public class MeResourceManager extends AbstractResourceManager {
             return new SCIMResponse(ResponseCodeConstants.CODE_CREATED,
                     encodedUser, responseHeaders);
 
-        } catch (CharonException e) {
+        } catch (AbstractCharonException e) {
             return encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return encodeSCIMException(e);
-        } catch (ConflictException e) {
-            return encodeSCIMException(e);
-        } catch (InternalErrorException e) {
-            return encodeSCIMException(e);
-        } catch (NotFoundException e) {
-            return encodeSCIMException(e);
+        } catch (Exception ex) {
+            return AbstractResourceManager.encodeSCIMException(new CharonException(ex.getMessage(), ex));
         }
     }
 
@@ -180,16 +171,10 @@ public class MeResourceManager extends AbstractResourceManager {
                 //throw internal server error.
                 throw new InternalErrorException(error);
             }
-        } catch (NotFoundException e) {
+        } catch (AbstractCharonException e) {
             return encodeSCIMException(e);
-        } catch (CharonException e) {
-            return encodeSCIMException(e);
-        } catch (InternalErrorException e) {
-            return encodeSCIMException(e);
-        } catch (NotImplementedException e) {
-            return encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return encodeSCIMException(e);
+        } catch (Exception ex) {
+            return AbstractResourceManager.encodeSCIMException(new CharonException(ex.getMessage(), ex));
         }
     }
 
@@ -268,16 +253,10 @@ public class MeResourceManager extends AbstractResourceManager {
             //put the uri of the User object in the response header parameter.
             return new SCIMResponse(ResponseCodeConstants.CODE_OK, encodedUser, httpHeaders);
 
-        } catch (NotFoundException e) {
+        } catch (AbstractCharonException e) {
             return encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return encodeSCIMException(e);
-        } catch (CharonException e) {
-            return encodeSCIMException(e);
-        } catch (InternalErrorException e) {
-            return encodeSCIMException(e);
-        } catch (NotImplementedException e) {
-            return encodeSCIMException(e);
+        } catch (Exception ex) {
+            return AbstractResourceManager.encodeSCIMException(new CharonException(ex.getMessage(), ex));
         }
     }
 
@@ -388,19 +367,13 @@ public class MeResourceManager extends AbstractResourceManager {
             //put the URI of the User object in the response header parameter.
             return new SCIMResponse(ResponseCodeConstants.CODE_OK, encodedUser, httpHeaders);
 
-        } catch (NotFoundException e) {
-            return encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return encodeSCIMException(e);
-        } catch (NotImplementedException e) {
-            return encodeSCIMException(e);
-        } catch (CharonException e) {
-            return encodeSCIMException(e);
-        } catch (InternalErrorException e) {
+        } catch (AbstractCharonException e) {
             return encodeSCIMException(e);
         } catch (RuntimeException e) {
             CharonException e1 = new CharonException("Error in performing the patch operation on user resource.", e);
             return encodeSCIMException(e1);
+        } catch (Exception ex) {
+            return AbstractResourceManager.encodeSCIMException(new CharonException(ex.getMessage(), ex));
         }
     }
 

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/ResourceTypeResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/ResourceTypeResourceManager.java
@@ -177,8 +177,7 @@ public class ResourceTypeResourceManager extends AbstractResourceManager {
      * @return
      * @throws CharonException
      */
-    private AbstractSCIMObject buildCombinedResourceType(AbstractSCIMObject userObject, AbstractSCIMObject groupObject)
-            throws CharonException {
+    private AbstractSCIMObject buildCombinedResourceType(AbstractSCIMObject userObject, AbstractSCIMObject groupObject) {
 
         AbstractSCIMObject rootObject = new AbstractSCIMObject();
         MultiValuedAttribute multiValuedAttribute = new MultiValuedAttribute(

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/ResourceTypeResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/ResourceTypeResourceManager.java
@@ -20,10 +20,10 @@ import org.wso2.charon3.core.attributes.MultiValuedAttribute;
 import org.wso2.charon3.core.attributes.SimpleAttribute;
 import org.wso2.charon3.core.encoder.JSONDecoder;
 import org.wso2.charon3.core.encoder.JSONEncoder;
+import org.wso2.charon3.core.exceptions.AbstractCharonException;
 import org.wso2.charon3.core.exceptions.BadRequestException;
 import org.wso2.charon3.core.exceptions.CharonException;
 import org.wso2.charon3.core.exceptions.InternalErrorException;
-import org.wso2.charon3.core.exceptions.NotFoundException;
 import org.wso2.charon3.core.extensions.UserManager;
 import org.wso2.charon3.core.objects.AbstractSCIMObject;
 import org.wso2.charon3.core.protocol.ResponseCodeConstants;
@@ -107,16 +107,12 @@ public class ResourceTypeResourceManager extends AbstractResourceManager {
             //put the uri of the resource type object in the response header parameter.
             return new SCIMResponse(ResponseCodeConstants.CODE_OK,
                     encodedObject, responseHeaders);
-        } catch (CharonException e) {
-            return encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return encodeSCIMException(e);
-        } catch (InternalErrorException e) {
-            return encodeSCIMException(e);
-        } catch (NotFoundException e) {
+        } catch (AbstractCharonException e) {
             return encodeSCIMException(e);
         } catch (JSONException e) {
             return null;
+        } catch (Exception ex) {
+            return AbstractResourceManager.encodeSCIMException(new CharonException(ex.getMessage(), ex));
         }
     }
 

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/ServiceProviderConfigResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/ServiceProviderConfigResourceManager.java
@@ -21,10 +21,10 @@ import org.slf4j.LoggerFactory;
 import org.wso2.charon3.core.config.CharonConfiguration;
 import org.wso2.charon3.core.encoder.JSONDecoder;
 import org.wso2.charon3.core.encoder.JSONEncoder;
+import org.wso2.charon3.core.exceptions.AbstractCharonException;
 import org.wso2.charon3.core.exceptions.BadRequestException;
 import org.wso2.charon3.core.exceptions.CharonException;
 import org.wso2.charon3.core.exceptions.InternalErrorException;
-import org.wso2.charon3.core.exceptions.NotFoundException;
 import org.wso2.charon3.core.extensions.UserManager;
 import org.wso2.charon3.core.objects.AbstractSCIMObject;
 import org.wso2.charon3.core.protocol.ResponseCodeConstants;
@@ -97,16 +97,12 @@ public class ServiceProviderConfigResourceManager extends AbstractResourceManage
             //put the uri of the service provider config object in the response header parameter.
             return new SCIMResponse(ResponseCodeConstants.CODE_OK,
                     encodedObject, responseHeaders);
-        } catch (CharonException e) {
-            return encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return encodeSCIMException(e);
-        } catch (InternalErrorException e) {
-            return encodeSCIMException(e);
-        } catch (NotFoundException e) {
+        } catch (AbstractCharonException e) {
             return encodeSCIMException(e);
         } catch (JSONException e) {
             return null;
+        } catch (Exception ex) {
+            return AbstractResourceManager.encodeSCIMException(new CharonException(ex.getMessage(), ex));
         }
     }
 

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/UserResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/UserResourceManager.java
@@ -109,6 +109,8 @@ public class UserResourceManager extends AbstractResourceManager {
 
         } catch (AbstractCharonException e) {
             return AbstractResourceManager.encodeSCIMException(e);
+        } catch (Exception ex) {
+            return AbstractResourceManager.encodeSCIMException(new CharonException(ex.getMessage(), ex));
         }
     }
 
@@ -184,6 +186,8 @@ public class UserResourceManager extends AbstractResourceManager {
             return AbstractResourceManager.encodeSCIMException(e);
         } catch (AbstractCharonException e) {
             return AbstractResourceManager.encodeSCIMException(e);
+        } catch (Exception ex) {
+            return AbstractResourceManager.encodeSCIMException(new CharonException(ex.getMessage(), ex));
         }
     }
 
@@ -207,10 +211,10 @@ public class UserResourceManager extends AbstractResourceManager {
                 //throw internal server error.
                 throw new InternalErrorException(error);
             }
-        } catch (NotFoundException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
         } catch (AbstractCharonException e) {
             return AbstractResourceManager.encodeSCIMException(e);
+        } catch (Exception ex) {
+            return AbstractResourceManager.encodeSCIMException(new CharonException(ex.getMessage(), ex));
         }
     }
 
@@ -329,6 +333,8 @@ public class UserResourceManager extends AbstractResourceManager {
             String error = "Error in tokenization of the input filter";
             CharonException charonException = new CharonException(error);
             return AbstractResourceManager.encodeSCIMException(charonException);
+        } catch (Exception ex) {
+            return AbstractResourceManager.encodeSCIMException(new CharonException(ex.getMessage(), ex));
         }
     }
 
@@ -410,6 +416,8 @@ public class UserResourceManager extends AbstractResourceManager {
             }
         } catch (AbstractCharonException e) {
             return AbstractResourceManager.encodeSCIMException(e);
+        } catch (Exception ex) {
+            return AbstractResourceManager.encodeSCIMException(new CharonException(ex.getMessage(), ex));
         }
     }
 
@@ -484,6 +492,8 @@ public class UserResourceManager extends AbstractResourceManager {
 
         } catch (AbstractCharonException e) {
             return AbstractResourceManager.encodeSCIMException(e);
+        } catch (Exception ex) {
+            return AbstractResourceManager.encodeSCIMException(new CharonException(ex.getMessage(), ex));
         }
     }
 
@@ -595,6 +605,8 @@ public class UserResourceManager extends AbstractResourceManager {
             return new SCIMResponse(ResponseCodeConstants.CODE_OK, encodedUser, httpHeaders);
         } catch (AbstractCharonException e) {
             return AbstractResourceManager.encodeSCIMException(e);
+        } catch (Exception ex) {
+            return AbstractResourceManager.encodeSCIMException(new CharonException(ex.getMessage(), ex));
         }
     }
 
@@ -605,11 +617,10 @@ public class UserResourceManager extends AbstractResourceManager {
      * @param startIndex
      * @param totalResults
      * @return
-     * @throws CharonException
      * @throws NotFoundException
      */
     protected ListedResource createListedResource(List<Object> users, int startIndex, int totalResults)
-            throws CharonException, NotFoundException {
+            throws NotFoundException {
         ListedResource listedResource = new ListedResource();
         listedResource.setSchema(SCIMConstants.LISTED_RESOURCE_CORE_SCHEMA_URI);
         listedResource.setTotalResults(totalResults);

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/UserResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/UserResourceManager.java
@@ -22,12 +22,11 @@ import org.slf4j.LoggerFactory;
 import org.wso2.charon3.core.attributes.Attribute;
 import org.wso2.charon3.core.encoder.JSONDecoder;
 import org.wso2.charon3.core.encoder.JSONEncoder;
+import org.wso2.charon3.core.exceptions.AbstractCharonException;
 import org.wso2.charon3.core.exceptions.BadRequestException;
 import org.wso2.charon3.core.exceptions.CharonException;
-import org.wso2.charon3.core.exceptions.ConflictException;
 import org.wso2.charon3.core.exceptions.InternalErrorException;
 import org.wso2.charon3.core.exceptions.NotFoundException;
-import org.wso2.charon3.core.exceptions.NotImplementedException;
 import org.wso2.charon3.core.extensions.UserManager;
 import org.wso2.charon3.core.objects.ListedResource;
 import org.wso2.charon3.core.objects.User;
@@ -66,11 +65,11 @@ public class UserResourceManager extends AbstractResourceManager {
 
     }
 
-    /*
+    /**
      * Retrieves a user resource given an unique user id. Mapped to HTTP GET request.
      *
      * @param id          - unique resource id
-     * @param usermanager - usermanager instance defined by the external implementor of charon
+     * @param userManager - usermanager instance defined by the external implementor of charon
      * @return SCIM response to be returned.
      */
     public SCIMResponse get(String id, UserManager userManager, String attributes, String excludeAttributes) {
@@ -108,16 +107,12 @@ public class UserResourceManager extends AbstractResourceManager {
                     SCIMConstants.USER_ENDPOINT) + "/" + user.getId());
             return new SCIMResponse(ResponseCodeConstants.CODE_OK, encodedUser, responseHeaders);
 
-        } catch (NotFoundException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (CharonException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (BadRequestException e) {
+        } catch (AbstractCharonException e) {
             return AbstractResourceManager.encodeSCIMException(e);
         }
     }
 
-    /*
+    /**
      * Returns SCIMResponse based on the sucess or failure of the create user operation
      *
      * @param scimObjectString -raw string containing user info
@@ -187,25 +182,18 @@ public class UserResourceManager extends AbstractResourceManager {
                 e.setStatus(ResponseCodeConstants.CODE_INTERNAL_ERROR);
             }
             return AbstractResourceManager.encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (ConflictException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (InternalErrorException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (NotFoundException e) {
+        } catch (AbstractCharonException e) {
             return AbstractResourceManager.encodeSCIMException(e);
         }
     }
 
-    /*
+    /**
      * Method of the ResourceManager that is mapped to HTTP Delete method..
      *
      * @param id          - unique resource id
-     * @param usermanager - usermanager instance defined by the external implementor of charon
+     * @param userManager - usermanager instance defined by the external implementor of charon
      * @return
      */
-
     public SCIMResponse delete(String id, UserManager userManager) {
         JSONEncoder encoder = null;
         try {
@@ -221,22 +209,16 @@ public class UserResourceManager extends AbstractResourceManager {
             }
         } catch (NotFoundException e) {
             return AbstractResourceManager.encodeSCIMException(e);
-        } catch (CharonException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (InternalErrorException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (NotImplementedException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (BadRequestException e) {
+        } catch (AbstractCharonException e) {
             return AbstractResourceManager.encodeSCIMException(e);
         }
     }
 
 
-    /*
+    /**
      * To list all the resources of resource endpoint.
      *
-     * @param usermanager
+     * @param userManager
      * @param filter
      * @param startIndex
      * @param count
@@ -341,27 +323,19 @@ public class UserResourceManager extends AbstractResourceManager {
                 //throw internal server error.
                 throw new InternalErrorException(error);
             }
-        } catch (CharonException e) {
+        } catch (AbstractCharonException e) {
             return AbstractResourceManager.encodeSCIMException(e);
-        } catch (NotFoundException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (InternalErrorException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (NotImplementedException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (IOException e) {
+        }  catch (IOException e) {
             String error = "Error in tokenization of the input filter";
             CharonException charonException = new CharonException(error);
             return AbstractResourceManager.encodeSCIMException(charonException);
         }
     }
 
-    /*
+    /**
      * this facilitates the querying using HTTP POST
      * @param resourceString
-     * @param usermanager
+     * @param userManager
      * @return
      */
 
@@ -434,25 +408,17 @@ public class UserResourceManager extends AbstractResourceManager {
                 //throw internal server error.
                 throw new InternalErrorException(error);
             }
-        } catch (CharonException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (NotFoundException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (InternalErrorException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (NotImplementedException e) {
+        } catch (AbstractCharonException e) {
             return AbstractResourceManager.encodeSCIMException(e);
         }
     }
 
-    /*
+    /**
      * To update the user by giving entire attribute set
      *
      * @param existingId
      * @param scimObjectString
-     * @param usermanager
+     * @param userManager
      * @return
      */
     public SCIMResponse updateWithPUT(String existingId, String scimObjectString, UserManager userManager,
@@ -516,15 +482,7 @@ public class UserResourceManager extends AbstractResourceManager {
             //put the uri of the User object in the response header parameter.
             return new SCIMResponse(ResponseCodeConstants.CODE_OK, encodedUser, httpHeaders);
 
-        } catch (NotFoundException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (CharonException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (InternalErrorException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (NotImplementedException e) {
+        } catch (AbstractCharonException e) {
             return AbstractResourceManager.encodeSCIMException(e);
         }
     }
@@ -635,23 +593,12 @@ public class UserResourceManager extends AbstractResourceManager {
             }
             //put the URI of the User object in the response header parameter.
             return new SCIMResponse(ResponseCodeConstants.CODE_OK, encodedUser, httpHeaders);
-        } catch (NotFoundException e) {
+        } catch (AbstractCharonException e) {
             return AbstractResourceManager.encodeSCIMException(e);
-        } catch (BadRequestException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (NotImplementedException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (CharonException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (InternalErrorException e) {
-            return AbstractResourceManager.encodeSCIMException(e);
-        } catch (RuntimeException e) {
-            CharonException e1 = new CharonException("Error in performing the patch operation on user resource.", e);
-            return AbstractResourceManager.encodeSCIMException(e1);
         }
     }
 
-    /*
+    /**
      * Creates the Listed Resource.
      *
      * @param users

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/UserResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/UserResourceManager.java
@@ -617,10 +617,8 @@ public class UserResourceManager extends AbstractResourceManager {
      * @param startIndex
      * @param totalResults
      * @return
-     * @throws NotFoundException
      */
-    protected ListedResource createListedResource(List<Object> users, int startIndex, int totalResults)
-            throws NotFoundException {
+    protected ListedResource createListedResource(List<Object> users, int startIndex, int totalResults) {
         ListedResource listedResource = new ListedResource();
         listedResource.setSchema(SCIMConstants.LISTED_RESOURCE_CORE_SCHEMA_URI);
         listedResource.setTotalResults(totalResults);

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/AbstractValidator.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/AbstractValidator.java
@@ -251,7 +251,7 @@ public abstract class AbstractValidator {
      * @param requestedExcludingAttributes
      */
     public static void validateReturnedAttributes(AbstractSCIMObject scimObject, String requestedAttributes,
-                                                  String requestedExcludingAttributes) throws CharonException {
+                                                  String requestedExcludingAttributes) {
         List<String> requestedAttributesList = null;
         List<String> requestedExcludingAttributesList = null;
 
@@ -461,7 +461,7 @@ public abstract class AbstractValidator {
                                                        String requestedExcludingAttributes, List<String>
                                                                requestedAttributesList,
                                                        List<String> requestedExcludingAttributesList,
-                                                       AbstractSCIMObject scimObject) throws CharonException {
+                                                       AbstractSCIMObject scimObject) {
         //check for never/request attributes.
         if (subSubAttribute.getReturned().equals(SCIMDefinitions.Returned.NEVER)) {
             scimObject.deleteSubSubAttribute(subSubAttribute.getName(), subAttribute.getName(), attribute.getName());
@@ -1050,7 +1050,7 @@ public abstract class AbstractValidator {
      */
     private static void checkForReadOnlyAndImmutableInComplexAttributes(Attribute newAttribute, Attribute oldAttribute,
                                                                         List<AttributeSchema> subAttributeSchemaList
-    ) throws CharonException, BadRequestException {
+    ) throws BadRequestException {
         //this is complex attribute case
         Map<String, Attribute> newSubAttributeList = ((ComplexAttribute) (newAttribute)).getSubAttributesList();
         Map<String, Attribute> oldSubAttributeList = ((ComplexAttribute) (oldAttribute)).getSubAttributesList();

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/AttributeSchema.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/AttributeSchema.java
@@ -15,8 +15,6 @@
  */
 package org.wso2.charon3.core.schema;
 
-import org.wso2.charon3.core.exceptions.CharonException;
-
 import java.util.List;
 
 /**
@@ -69,7 +67,7 @@ public interface AttributeSchema {
 
     public AttributeSchema getSubAttributeSchema(String subAttribute);
 
-    public void removeSubAttribute(String subAttributeName) throws CharonException;
+    public void removeSubAttribute(String subAttributeName);
 
 }
 

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMAttributeSchema.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMAttributeSchema.java
@@ -16,7 +16,6 @@
 
 package org.wso2.charon3.core.schema;
 
-import org.wso2.charon3.core.exceptions.CharonException;
 import org.wso2.charon3.core.utils.CopyUtil;
 
 import java.io.Serializable;
@@ -192,7 +191,7 @@ public class SCIMAttributeSchema implements AttributeSchema, Serializable {
     }
 
     @Override
-    public void removeSubAttribute(String subAttributeName) throws CharonException {
+    public void removeSubAttribute(String subAttributeName) {
         ArrayList<AttributeSchema> tempSubAttributes = (ArrayList<AttributeSchema>) CopyUtil.deepCopy(subAttributes);
         int count = 0;
         for (AttributeSchema subAttributeSchema : tempSubAttributes) {

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/AttributeUtil.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/AttributeUtil.java
@@ -43,7 +43,7 @@ public class AttributeUtil {
      */
     public static Object getAttributeValueFromString(Object attributeValue,
                                                      SCIMDefinitions.DataType dataType)
-            throws CharonException, BadRequestException {
+            throws CharonException {
         if (attributeValue == null) {
             return attributeValue;
         }
@@ -127,7 +127,7 @@ public class AttributeUtil {
         }
     }
 
-    public static String parseReference(String referenceString) throws CharonException {
+    public static String parseReference(String referenceString) {
         //TODO: Need a better way for doing this. Think of the way to handle reference types
         return referenceString;
     }
@@ -151,7 +151,7 @@ public class AttributeUtil {
      *
      * @param booleanValue
      */
-    public static Boolean parseBoolean(Object booleanValue) throws BadRequestException {
+    public static Boolean parseBoolean(Object booleanValue) {
         try {
             return ((Boolean) booleanValue);
         } catch (Exception e) {

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/CopyUtil.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/CopyUtil.java
@@ -17,7 +17,6 @@ package org.wso2.charon3.core.utils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wso2.charon3.core.exceptions.CharonException;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -34,7 +33,7 @@ public class CopyUtil {
 
     private static final Logger log = LoggerFactory.getLogger(CopyUtil.class);
 
-    public static Object deepCopy(Object oldObject) throws CharonException {
+    public static Object deepCopy(Object oldObject) {
         ObjectOutputStream objOutPutStream;
         ObjectInputStream objInputStream;
         Object newObject = null;

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/ResourceManagerUtil.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/ResourceManagerUtil.java
@@ -18,7 +18,6 @@ package org.wso2.charon3.core.utils;
 
 import org.wso2.charon3.core.config.CharonConfiguration;
 import org.wso2.charon3.core.exceptions.BadRequestException;
-import org.wso2.charon3.core.exceptions.CharonException;
 import org.wso2.charon3.core.schema.AttributeSchema;
 import org.wso2.charon3.core.schema.SCIMDefinitions;
 import org.wso2.charon3.core.schema.SCIMResourceTypeSchema;
@@ -45,8 +44,7 @@ public class ResourceManagerUtil {
      */
     public static Map<String, Boolean> getOnlyRequiredAttributesURIs(SCIMResourceTypeSchema schema,
                                                                      String requestedAttributes,
-                                                                     String requestedExcludingAttributes)
-            throws CharonException {
+                                                                     String requestedExcludingAttributes) {
 
         ArrayList<AttributeSchema> attributeSchemaArrayList = (ArrayList<AttributeSchema>)
                 CopyUtil.deepCopy(schema.getAttributesList());
@@ -124,8 +122,7 @@ public class ResourceManagerUtil {
                                                          String requestedAttributes,
                                                          String requestedExcludingAttributes,
                                                          List<String> requestedAttributesList,
-                                                         List<String> requestedExcludingAttributesList)
-            throws CharonException {
+                                                         List<String> requestedExcludingAttributesList) {
         if (attributeSchema.getType().equals(SCIMDefinitions.DataType.COMPLEX)) {
 
             AttributeSchema realAttributeSchema = null;
@@ -208,8 +205,7 @@ public class ResourceManagerUtil {
                                                             String requestedAttributes,
                                                             String requestedExcludingAttributes,
                                                             List<String> requestedAttributesList,
-                                                            List<String> requestedExcludingAttributesList)
-            throws CharonException {
+                                                            List<String> requestedExcludingAttributesList) {
 
         if (subAttribute.getType().equals(SCIMDefinitions.DataType.COMPLEX)) {
 
@@ -374,8 +370,7 @@ public class ResourceManagerUtil {
      * @param attributeName
      * @throws CharonException
      */
-    private static void removeAttributesFromList(List<AttributeSchema> attributeSchemaList, String attributeName)
-            throws CharonException {
+    private static void removeAttributesFromList(List<AttributeSchema> attributeSchemaList, String attributeName) {
         List<AttributeSchema> tempList = (List<AttributeSchema>) CopyUtil.deepCopy(attributeSchemaList);
         int count = 0;
         for (AttributeSchema attributeSchema : tempList) {
@@ -386,7 +381,7 @@ public class ResourceManagerUtil {
         }
     }
 
-    public static Map<String, Boolean> getAllAttributeURIs(SCIMResourceTypeSchema schema) throws CharonException {
+    public static Map<String, Boolean> getAllAttributeURIs(SCIMResourceTypeSchema schema) {
         return getOnlyRequiredAttributesURIs(schema, null, null);
     }
 

--- a/modules/charon-utils/src/main/java/org/wso2/charon3/utils/DefaultCharonManager.java
+++ b/modules/charon-utils/src/main/java/org/wso2/charon3/utils/DefaultCharonManager.java
@@ -20,7 +20,6 @@ package org.wso2.charon3.utils;
 import org.wso2.charon3.core.encoder.JSONDecoder;
 import org.wso2.charon3.core.encoder.JSONEncoder;
 import org.wso2.charon3.core.exceptions.CharonException;
-import org.wso2.charon3.core.exceptions.FormatNotSupportedException;
 import org.wso2.charon3.core.extensions.UserManager;
 import org.wso2.charon3.core.protocol.endpoints.AbstractResourceManager;
 import org.wso2.charon3.core.schema.SCIMConstants;
@@ -48,7 +47,7 @@ public class DefaultCharonManager {
     /**
      * Perform initialization.
      */
-    private void init() throws CharonException {
+    private void init() {
         //Define endpoint urls to be used in Location Header
         endpointURLs.put(SCIMConstants.USER_ENDPOINT, USERS_URL);
         endpointURLs.put(SCIMConstants.GROUP_ENDPOINT, GROUPS_URL);
@@ -56,7 +55,7 @@ public class DefaultCharonManager {
         registerEndpointURLs();
     }
 
-    private DefaultCharonManager() throws CharonException {
+    private DefaultCharonManager() {
         init();
     }
 
@@ -86,7 +85,7 @@ public class DefaultCharonManager {
      *
      * @return
      */
-    public JSONDecoder getDecoder() throws FormatNotSupportedException {
+    public JSONDecoder getDecoder() {
         return jsonDecoder;
     }
 
@@ -95,11 +94,11 @@ public class DefaultCharonManager {
      *
      * @return
      */
-    public JSONEncoder getEncoder() throws FormatNotSupportedException {
+    public JSONEncoder getEncoder() {
         return jsonEncoder;
     }
 
-    public UserManager getUserManager() throws CharonException {
+    public UserManager getUserManager() {
         return userManager;
     }
 

--- a/modules/charon-utils/src/main/java/org/wso2/charon3/utils/supportutils/CopyUtil.java
+++ b/modules/charon-utils/src/main/java/org/wso2/charon3/utils/supportutils/CopyUtil.java
@@ -17,7 +17,6 @@ package org.wso2.charon3.utils.supportutils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wso2.charon3.core.exceptions.CharonException;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -32,7 +31,7 @@ public class CopyUtil {
 
     private static final Logger logger = LoggerFactory.getLogger(CopyUtil.class);
 
-    public static Object deepCopy(Object oldObject) throws CharonException {
+    public static Object deepCopy(Object oldObject) {
         ObjectOutputStream objOutPutStream;
         ObjectInputStream objInputStream;
         Object newObject = null;


### PR DESCRIPTION
The charon library defined a lot of unnecessary redundant throws declarations that have been removed with this commit