### PR TITLE
Fix NPE by letting DefaultAttributeFactory handle ListResponse

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/ListedResource.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/ListedResource.java
@@ -16,13 +16,17 @@
 package org.wso2.charon3.core.objects;
 
 import org.wso2.charon3.core.attributes.Attribute;
+import org.wso2.charon3.core.attributes.DefaultAttributeFactory;
 import org.wso2.charon3.core.attributes.MultiValuedAttribute;
 import org.wso2.charon3.core.attributes.SimpleAttribute;
 import org.wso2.charon3.core.schema.SCIMConstants;
+import org.wso2.charon3.core.schema.SCIMSchemaDefinitions;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
+import static org.wso2.charon3.core.utils.LambdaExceptionUtils.rethrowBiConsumer;
 
 /**
  * Represents the listed resource object which is a collection of resources.
@@ -56,9 +60,8 @@ public class ListedResource extends AbstractSCIMObject {
         if (!isAttributeExist(SCIMConstants.ListedResourceSchemaConstants.TOTAL_RESULTS)) {
             SimpleAttribute totalResultsAttribute =
                 new SimpleAttribute(SCIMConstants.ListedResourceSchemaConstants.TOTAL_RESULTS, totalResults);
-            //No need to let the Default attribute factory to handle the attribute, as this is
-            //not officially defined as SCIM attribute, hence have no characteristics defined
-            //TODO: may be we can let the default attribute factory to handle it?
+            rethrowBiConsumer(DefaultAttributeFactory::createAttribute)
+                .accept(SCIMSchemaDefinitions.SCIMListResponseSchemaDefinition.TOTAL_RESULTS, totalResultsAttribute);
             attributeList.put(SCIMConstants.ListedResourceSchemaConstants.TOTAL_RESULTS, totalResultsAttribute);
         } else {
             ((SimpleAttribute) attributeList.get(SCIMConstants.ListedResourceSchemaConstants.TOTAL_RESULTS))
@@ -86,12 +89,11 @@ public class ListedResource extends AbstractSCIMObject {
      */
     public void setItemsPerPage(int itemsPerPage) {
         if (!isAttributeExist(SCIMConstants.ListedResourceSchemaConstants.ITEMS_PER_PAGE)) {
-            SimpleAttribute totalResultsAttribute =
+            SimpleAttribute itemsPerPageAttribute =
                 new SimpleAttribute(SCIMConstants.ListedResourceSchemaConstants.ITEMS_PER_PAGE, itemsPerPage);
-            //No need to let the Default attribute factory to handle the attribute, as this is
-            //not officially defined as SCIM attribute, hence have no characteristics defined
-            //TODO: may be we can let the default attribute factory to handle it?
-            attributeList.put(SCIMConstants.ListedResourceSchemaConstants.ITEMS_PER_PAGE, totalResultsAttribute);
+            rethrowBiConsumer(DefaultAttributeFactory::createAttribute)
+                .accept(SCIMSchemaDefinitions.SCIMListResponseSchemaDefinition.ITEMS_PER_PAGE, itemsPerPageAttribute);
+            attributeList.put(SCIMConstants.ListedResourceSchemaConstants.ITEMS_PER_PAGE, itemsPerPageAttribute);
         } else {
             ((SimpleAttribute) attributeList.get(SCIMConstants.ListedResourceSchemaConstants.ITEMS_PER_PAGE))
                 .setValue(itemsPerPage);
@@ -118,12 +120,11 @@ public class ListedResource extends AbstractSCIMObject {
      */
     public void setStartIndex(int startIndex) {
         if (!isAttributeExist(SCIMConstants.ListedResourceSchemaConstants.START_INDEX)) {
-            SimpleAttribute totalResultsAttribute =
+            SimpleAttribute startIndexAttribute =
                 new SimpleAttribute(SCIMConstants.ListedResourceSchemaConstants.START_INDEX, startIndex);
-            //No need to let the Default attribute factory to handle the attribute, as this is
-            //not officially defined as SCIM attribute, hence have no charactersitics defined
-            //TODO: may be we can let the default attribute factory to handle it?
-            attributeList.put(SCIMConstants.ListedResourceSchemaConstants.START_INDEX, totalResultsAttribute);
+            rethrowBiConsumer(DefaultAttributeFactory::createAttribute)
+                .accept(SCIMSchemaDefinitions.SCIMListResponseSchemaDefinition.START_INDEX, startIndexAttribute);
+            attributeList.put(SCIMConstants.ListedResourceSchemaConstants.START_INDEX, startIndexAttribute);
         } else {
             ((SimpleAttribute) attributeList.get(SCIMConstants.ListedResourceSchemaConstants.START_INDEX))
                 .setValue(startIndex);
@@ -141,6 +142,8 @@ public class ListedResource extends AbstractSCIMObject {
         if (!isAttributeExist(SCIMConstants.ListedResourceSchemaConstants.RESOURCES)) {
             MultiValuedAttribute resourcesAttribute =
                 new MultiValuedAttribute(SCIMConstants.ListedResourceSchemaConstants.RESOURCES);
+            rethrowBiConsumer(DefaultAttributeFactory::createAttribute)
+                .accept(SCIMSchemaDefinitions.SCIMListResponseSchemaDefinition.RESOURCES, resourcesAttribute);
             resourcesAttribute.setComplexValueWithSetOfSubAttributes(valueWithAttributes);
             attributeList.put(SCIMConstants.ListedResourceSchemaConstants.RESOURCES, resourcesAttribute);
         } else {
@@ -168,6 +171,8 @@ public class ListedResource extends AbstractSCIMObject {
         if (!isAttributeExist(SCIMConstants.ListedResourceSchemaConstants.RESOURCES)) {
             MultiValuedAttribute resourcesAttribute =
                 new MultiValuedAttribute(SCIMConstants.ListedResourceSchemaConstants.RESOURCES);
+            rethrowBiConsumer(DefaultAttributeFactory::createAttribute)
+                .accept(SCIMSchemaDefinitions.SCIMListResponseSchemaDefinition.RESOURCES, resourcesAttribute);
             resourcesAttribute.setComplexValueWithSetOfSubAttributes(scimResourceType.getAttributeList());
             attributeList.put(SCIMConstants.ListedResourceSchemaConstants.RESOURCES, resourcesAttribute);
         } else {

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMConstants.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMConstants.java
@@ -114,9 +114,26 @@ public class SCIMConstants {
     public static class ListedResourceSchemaConstants {
 
         public static final String TOTAL_RESULTS = "totalResults";
+        public static final String TOTAL_RESULTS_URI = LISTED_RESOURCE_CORE_SCHEMA_URI + ":" + TOTAL_RESULTS;
+        public static final String TOTAL_RESULTS_DESC = "The total number of results returned by the list or query " +
+                "operation. The value may be larger than the number of resources returned, such as when returning a " +
+                "single page of results where multiple pages are available.";
+
         public static final String RESOURCES = "Resources";
+        public static final String RESOURCES_URI = LISTED_RESOURCE_CORE_SCHEMA_URI + ":" + RESOURCES;
+        public static final String RESOURCES_DESC = "A multi-valued list of complex objects containing the requested" +
+                " resources. This MAY be a subset of the full set of resources if pagination is requested. REQUIRED " +
+                "if \"totalResults\" is non-zero.";
+
         public static final String ITEMS_PER_PAGE = "itemsPerPage";
+        public static final String ITEMS_PER_PAGE_URI = LISTED_RESOURCE_CORE_SCHEMA_URI + ":" + ITEMS_PER_PAGE;
+        public static final String ITEMS_PER_PAGE_DESC = "The number of resources returned in a list response page. " +
+                "REQUIRED when partial results are returned due to pagination.";
+
         public static final String START_INDEX = "startIndex";
+        public static final String START_INDEX_URI = LISTED_RESOURCE_CORE_SCHEMA_URI + ":" + START_INDEX;
+        public static final String START_INDEX_DESC = "The 1-based index of the first result in the current set of " +
+                "list results. REQUIRED when partial results are returned due to pagination.";
     }
 
     /**

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMSchemaDefinitions.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMSchemaDefinitions.java
@@ -1130,7 +1130,7 @@ public class SCIMSchemaDefinitions {
     }
 
     /**
-     * SCIM defined resourceType  schemas.
+     * SCIM defined resourceType schemas.
      */
     public static class SCIMResourceTypeSchemaDefinition {
 
@@ -1219,6 +1219,54 @@ public class SCIMSchemaDefinitions {
 
     }
 
+    /**
+     * SCIM defined ListResponse schemas.
+     */
+    public static class SCIMListResponseSchemaDefinition {
+
+        public static final SCIMAttributeSchema TOTAL_RESULTS =
+                SCIMAttributeSchema.createSCIMAttributeSchema(
+                        SCIMConstants.ListedResourceSchemaConstants.TOTAL_RESULTS_URI,
+                        SCIMConstants.ListedResourceSchemaConstants.TOTAL_RESULTS,
+                        SCIMDefinitions.DataType.INTEGER, false,
+                        SCIMConstants.ListedResourceSchemaConstants.TOTAL_RESULTS_DESC, true, false,
+                        SCIMDefinitions.Mutability.READ_ONLY, SCIMDefinitions.Returned.DEFAULT,
+                        SCIMDefinitions.Uniqueness.NONE, null, null, null);
+
+        /*
+         * sub attributes are set to <code>null</code>, which is not correct,
+         * but we cannot know the type, because it is resource type dependent
+         * e.g. users have different attributes than groups
+         */
+        public static final SCIMAttributeSchema RESOURCES =
+                SCIMAttributeSchema.createSCIMAttributeSchema(
+                        SCIMConstants.ListedResourceSchemaConstants.RESOURCES_URI,
+                        SCIMConstants.ListedResourceSchemaConstants.RESOURCES,
+                        SCIMDefinitions.DataType.COMPLEX, true,
+                        SCIMConstants.ListedResourceSchemaConstants.RESOURCES_DESC, false, false,
+                        SCIMDefinitions.Mutability.READ_ONLY, SCIMDefinitions.Returned.DEFAULT,
+                        SCIMDefinitions.Uniqueness.NONE, null, null, null);
+
+        public static final SCIMAttributeSchema START_INDEX  =
+                SCIMAttributeSchema.createSCIMAttributeSchema(
+                        SCIMConstants.ListedResourceSchemaConstants.START_INDEX_URI,
+                        SCIMConstants.ListedResourceSchemaConstants.START_INDEX,
+                        SCIMDefinitions.DataType.INTEGER, true,
+                        SCIMConstants.ListedResourceSchemaConstants.START_INDEX_DESC, false, false,
+                        SCIMDefinitions.Mutability.READ_ONLY, SCIMDefinitions.Returned.DEFAULT,
+                        SCIMDefinitions.Uniqueness.NONE, null, null, null);
+
+        public static final SCIMAttributeSchema ITEMS_PER_PAGE  =
+                SCIMAttributeSchema.createSCIMAttributeSchema(
+                        SCIMConstants.ListedResourceSchemaConstants.ITEMS_PER_PAGE_URI,
+                        SCIMConstants.ListedResourceSchemaConstants.ITEMS_PER_PAGE,
+                        SCIMDefinitions.DataType.INTEGER, true,
+                        SCIMConstants.ListedResourceSchemaConstants.ITEMS_PER_PAGE_DESC, false, false,
+                        SCIMDefinitions.Mutability.READ_ONLY, SCIMDefinitions.Returned.DEFAULT,
+                        SCIMDefinitions.Uniqueness.NONE, null, null, null);
+
+    }
+
     /*
      * **********SCIM defined User Resource Schema.****************************
      */
@@ -1289,5 +1337,17 @@ public class SCIMSchemaDefinitions {
                     SCIMResourceTypeSchemaDefinition.DESCRIPTION,
                     SCIMResourceTypeSchemaDefinition.SCHEMA,
                     SCIMResourceTypeSchemaDefinition.SCHEMA_EXTENSIONS);
+
+    /*
+     * **********SCIM defined ListResponse Schema.****************************
+     */
+
+    public static final SCIMResourceTypeSchema SCIM_LIST_RESPONSE_SCHEMA =
+            SCIMResourceTypeSchema.createSCIMResourceSchema(
+                    new ArrayList<String>(Arrays.asList(SCIMConstants.LISTED_RESOURCE_CORE_SCHEMA_URI)),
+                    SCIMListResponseSchemaDefinition.TOTAL_RESULTS,
+                    SCIMListResponseSchemaDefinition.RESOURCES,
+                    SCIMListResponseSchemaDefinition.START_INDEX,
+                    SCIMListResponseSchemaDefinition.ITEMS_PER_PAGE);
 
 }


### PR DESCRIPTION
## Purpose
PR #183 introduced a NPE when encoding a ListResponse. The NPE occurred because the JSONEncoder expects a schema URI for each attribute. The attributes of the ListResponse are set without specifying a schema, so the schema URI is absent.

## Goals
Fix this NPE.

## Approach
Define SCIMAttributeSchema for each attribute of ListResponse, so the URI is properly set and the JSONEncoder does not fail with NPE.

## Related PRs
#183 
