### PR TITLE
Fix processing of count and startIndex in case of get-request

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/BulkResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/BulkResourceManager.java
@@ -105,8 +105,9 @@ public class BulkResourceManager extends AbstractResourceManager {
     }
 
     @Override
-    public SCIMResponse listWithGET(UserManager userManager, String filter, int startIndex, int count, String sortBy,
-                                    String sortOrder, String domainName, String attributes, String excludeAttributes) {
+    public SCIMResponse listWithGET(UserManager userManager, String filter, Integer startIndex, Integer count,
+                                    String sortBy, String sortOrder, String domainName, String attributes,
+                                    String excludeAttributes) {
         return null;
     }
 

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
@@ -230,23 +230,18 @@ public class GroupResourceManager extends AbstractResourceManager {
      * @return
      */
     @Override
-    public SCIMResponse listWithGET(UserManager userManager, String filter, int startIndex,
-                                    int count, String sortBy, String sortOrder, String domainName,
+    public SCIMResponse listWithGET(UserManager userManager, String filter, Integer startIndexInt,
+                                    Integer countInt, String sortBy, String sortOrder, String domainName,
                                     String attributes, String excludeAttributes) {
-
-        //According to SCIM 2.0 spec minus values will be considered as 0
-        if (count < 0) {
-            count = 0;
-        }
-        //According to SCIM 2.0 spec minus values will be considered as 1
-        if (startIndex < 1) {
-            startIndex = 1;
-        }
 
         FilterTreeManager filterTreeManager = null;
         Node rootNode = null;
         JSONEncoder encoder = null;
         try {
+
+            int count = ResourceManagerUtil.processCount(countInt == null ? null : String.valueOf(countInt));
+            int startIndex = ResourceManagerUtil.processStartIndex(startIndexInt == null ?
+                    null : String.valueOf(startIndexInt));
 
             //check whether provided sortOrder is valid or not
             if (sortOrder != null) {

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/MeResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/MeResourceManager.java
@@ -195,7 +195,7 @@ public class MeResourceManager extends AbstractResourceManager {
 
     @Override
     public SCIMResponse listWithGET(UserManager userManager, String filter,
-                                    int startIndex, int count, String sortBy, String sortOrder,
+                                    Integer startIndex, Integer count, String sortBy, String sortOrder,
                                     String domainName, String attributes, String excludeAttributes) {
         return null;
     }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/ResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/ResourceManager.java
@@ -70,8 +70,8 @@ public interface ResourceManager {
      * @return
      */
     public SCIMResponse listWithGET(UserManager userManager, String filter,
-                                    int startIndex, int count, String sortBy, String sortOrder, String domainName,
-                                    String attributes, String excludeAttributes);
+                                    Integer startIndex, Integer count, String sortBy, String sortOrder,
+                                    String domainName, String attributes, String excludeAttributes);
 
     /*
      * query resources

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/ResourceTypeResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/ResourceTypeResourceManager.java
@@ -138,8 +138,9 @@ public class ResourceTypeResourceManager extends AbstractResourceManager {
     }
 
     @Override
-    public SCIMResponse listWithGET(UserManager userManager, String filter, int startIndex, int count, String sortBy,
-                                    String sortOrder, String domainName, String attributes, String excludeAttributes) {
+    public SCIMResponse listWithGET(UserManager userManager, String filter, Integer startIndex, Integer count,
+                                    String sortBy, String sortOrder, String domainName, String attributes,
+                                    String excludeAttributes) {
 
         String error = "Request is undefined";
         BadRequestException badRequestException = new BadRequestException(error, ResponseCodeConstants.INVALID_PATH);

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/ServiceProviderConfigResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/ServiceProviderConfigResourceManager.java
@@ -126,8 +126,9 @@ public class ServiceProviderConfigResourceManager extends AbstractResourceManage
     }
 
     @Override
-    public SCIMResponse listWithGET(UserManager userManager, String filter, int startIndex, int count, String sortBy,
-                                    String sortOrder, String domainName, String attributes, String excludeAttributes) {
+    public SCIMResponse listWithGET(UserManager userManager, String filter, Integer startIndex, Integer count,
+                                    String sortBy, String sortOrder, String domainName, String attributes,
+                                    String excludeAttributes) {
         String error = "Request is undefined";
         BadRequestException badRequestException = new BadRequestException(error, ResponseCodeConstants.INVALID_PATH);
         return encodeSCIMException(badRequestException);

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/UserResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/UserResourceManager.java
@@ -248,7 +248,8 @@ public class UserResourceManager extends AbstractResourceManager {
      * @return
      */
     public SCIMResponse listWithGET(UserManager userManager, String filter,
-                                    int startIndex, int count, String sortBy, String sortOrder, String domainName,
+                                    Integer startIndexInt, Integer countInt, String sortBy, String sortOrder,
+                                    String domainName,
                                     String attributes, String excludeAttributes) {
 
         FilterTreeManager filterTreeManager = null;
@@ -256,15 +257,10 @@ public class UserResourceManager extends AbstractResourceManager {
         JSONEncoder encoder = null;
 
         try {
+            int count = ResourceManagerUtil.processCount(countInt == null ? null : String.valueOf(countInt));
+            int startIndex = ResourceManagerUtil.processStartIndex(startIndexInt == null ?
+                    null : String.valueOf(startIndexInt));
 
-            //According to SCIM 2.0 spec minus values will be considered as 0
-            if (count < 0) {
-                count = 0;
-            }
-            //According to SCIM 2.0 spec minus values will be considered as 1
-            if (startIndex < 1) {
-                startIndex = 1;
-            }
             if (sortOrder != null) {
                 if (!(sortOrder.equalsIgnoreCase(SCIMConstants.OperationalConstants.ASCENDING)
                         || sortOrder.equalsIgnoreCase(SCIMConstants.OperationalConstants.DESCENDING))) {


### PR DESCRIPTION
Fix processing of count and startIndex in case of get-request

The values were incorrectly handled if the client left the values
unspecified.
@see https://tools.ietf.org/html/rfc7644#section-3.4.2.4