### PR TITLE
fix attribute parts computation for PATCH to manage urn:ietf:params:scim:schemas:extension:enterprise:2.0:User

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/PatchOperationUtil.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/PatchOperationUtil.java
@@ -42,6 +42,7 @@ import org.wso2.charon3.core.schema.ServerSideValidator;
 import org.wso2.charon3.core.utils.codeutils.ExpressionNode;
 import org.wso2.charon3.core.utils.codeutils.PatchOperation;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -119,7 +120,7 @@ public class PatchOperationUtil {
         if (parts.length == 3) {
             parts[0] = parts[0] + parts[2];
         }
-        String[] attributeParts = parts[0].split("[\\.]");
+        String[] attributeParts = getAttributeParts(parts[0]);
 
         if (attributeParts.length == 1) {
 
@@ -134,6 +135,37 @@ public class PatchOperationUtil {
             doPatchRemoveWithFiltersForLevelThree(oldResource, attributeParts, expressionNode);
         }
         return oldResource;
+    }
+
+    /**
+     * Calculate the parts of an attribute URI
+     * @param attributeURI
+     * @return
+     */
+    private static String[] getAttributeParts(String attributeURI) {
+        ArrayList<String> tempAttributeNames = new ArrayList<>();
+        String extensionURI = "";
+        String[] attributeURIParts = attributeURI.split(":");
+
+        StringBuffer buf = new StringBuffer();
+        for (int i = 0; i < attributeURIParts.length - 1; ++i) {
+            buf.append(":");
+            buf.append(attributeURIParts[i]);
+        }
+        extensionURI = buf.toString();
+
+        String attributeNameString = attributeURIParts[attributeURIParts.length - 1];
+        String[] attributeNames = attributeNameString.split("\\.");
+
+        if (attributeURIParts.length > 1) {
+            tempAttributeNames.add(extensionURI.substring(1));
+        }
+
+        for (int i = 0; i < attributeNames.length; i++) {
+            tempAttributeNames.add(attributeNames[i]);
+        }
+
+        return tempAttributeNames.toArray(attributeNames);
     }
 
     /*
@@ -471,7 +503,7 @@ public class PatchOperationUtil {
     private static AbstractSCIMObject doPatchRemoveWithoutFilters
     (String[] parts, AbstractSCIMObject oldResource) throws BadRequestException, CharonException {
 
-        String[] attributeParts = parts[0].split("[\\.]");
+        String[] attributeParts = getAttributeParts(parts[0]);
         if (attributeParts.length == 1) {
 
             Attribute attribute = oldResource.getAttribute(parts[0]);
@@ -810,7 +842,7 @@ public class PatchOperationUtil {
                                                                          String[] parts)
             throws BadRequestException, CharonException, InternalErrorException {
 
-        String[] attributeParts = parts[0].split("[\\.]");
+        String[] attributeParts = getAttributeParts(parts[0]);
 
         if (attributeParts.length == 1) {
 
@@ -1666,7 +1698,7 @@ public class PatchOperationUtil {
                 if (parts.length == 3) {
                     parts[0] = parts[0] + parts[2];
                 }
-                String[] attributeParts = parts[0].split("[\\.]");
+                String[] attributeParts = getAttributeParts(parts[0]);
 
                 if (attributeParts.length == 1) {
 


### PR DESCRIPTION
## Purpose
A change has been done in WSO2 IS 5.8.0 to be compliant with SCIM 2 specification regarding urn:ietf:params:scim:schemas:extension:enterprise:2.0:User. 

attributeName "EnterpriseUser" has been renamed to "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"

But the underlying code is not compatible with this change. AttributeName is not split well for PATCH operations.

## Goals
This fix change the parsing code of AttributeName to manage this use case.

## Approach
Add a method "getAttributeParts" to calculate the parts and detect the use of a schema in an AttributeName. And change the legacy splitting code with this method

## User stories
N/A

## Release note
Fix AttributeName splitting when using PATCH with urn:ietf:params:scim:schemas:extension:enterprise:2.0:User

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
curl -v -k --user admin:admin -X PATCH -d '{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"],"Operations":[{"op":"replace","path":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:employeeNumber","value": "xxx"}]}' --header "Content-Type:application/json" https://localhost:9443/scim2/Users/673b0308-1473-4590-b1cd-dbfce642caa3

response before the fix:
{"schemas":["urn:ietf:params:scim:api:messages:2.0:Error"],"scimType":"noTarget","detail":"No such attribute with the name : urn:ietf:params:scim:schemas:extension:enterprise:2","status":"400"}

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
JDK 1.8.0, WSO2 IS 5.8.0
 
## Learning
N/A