### PR TITLE
Fix versioning

### DIFF
--- a/modules/charon-core/pom.xml
+++ b/modules/charon-core/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.charon</groupId>
         <artifactId>charon-parent</artifactId>
-        <version>3.1.33-wso2v4-SNAPSHOT</version>
+        <version>3.1.33-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/charon-impl/pom.xml
+++ b/modules/charon-impl/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.charon</groupId>
         <artifactId>charon-parent</artifactId>
-        <version>3.1.33-wso2v4-SNAPSHOT</version>
+        <version>3.1.33-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/charon-samples/pom.xml
+++ b/modules/charon-samples/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.charon</groupId>
         <artifactId>charon-parent</artifactId>
-        <version>3.1.33-wso2v4-SNAPSHOT</version>
+        <version>3.1.33-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/charon-utils/pom.xml
+++ b/modules/charon-utils/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.charon</groupId>
         <artifactId>charon-parent</artifactId>
-        <version>3.1.33-wso2v4-SNAPSHOT</version>
+        <version>3.1.33-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <groupId>org.wso2.charon</groupId>
     <artifactId>charon-parent</artifactId>
     <packaging>pom</packaging>
-    <version>3.1.33-wso2v4-SNAPSHOT</version>
+    <version>3.1.33-SNAPSHOT</version>
     <name>WSO2 Charon - Parent</name>
     <description>WSO2 Charon - SCIM Implementation</description>
     <url>http://wso2.com</url>


### PR DESCRIPTION
## Purpose
Charon versioning used to be in the following pattern,
https://github.com/wso2/charon/releases/tag/v3.1.31
https://github.com/wso2/charon/releases/tag/v3.1.32
but it got changed with,
https://github.com/wso2/charon/releases/tag/v3.1.33-wso2v3

This PR reset versioning to the initial pattern.