### PR TITLE
Add scimType to all error responses

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONEncoder.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONEncoder.java
@@ -26,7 +26,6 @@ import org.wso2.charon3.core.attributes.MultiValuedAttribute;
 import org.wso2.charon3.core.attributes.SimpleAttribute;
 import org.wso2.charon3.core.config.SCIMConfigConstants;
 import org.wso2.charon3.core.exceptions.AbstractCharonException;
-import org.wso2.charon3.core.exceptions.BadRequestException;
 import org.wso2.charon3.core.exceptions.CharonException;
 import org.wso2.charon3.core.exceptions.InternalErrorException;
 import org.wso2.charon3.core.objects.SCIMObject;
@@ -88,9 +87,7 @@ public class JSONEncoder {
         try {
             //construct error object with details in the exception
             errorObject.put(ResponseCodeConstants.SCHEMAS, new String[]{exception.getSchemas()});
-            if (exception instanceof BadRequestException) {
-                errorObject.put(ResponseCodeConstants.SCIM_TYPE, ((BadRequestException) (exception)).getScimType());
-            }
+            errorObject.put(ResponseCodeConstants.SCIM_TYPE, String.valueOf(exception.getScimType()));
             errorObject.put(ResponseCodeConstants.DETAIL, String.valueOf(exception.getDetail()));
             errorObject.put(ResponseCodeConstants.STATUS, String.valueOf(exception.getStatus()));
             //construct the full json obj.


### PR DESCRIPTION
RFC7644 is defining the scimType as an optional attribute in chapter 3.12. It defines explicit scimType codes within table 9 in chapter 3.12 but is not explicitly prohibiting the use in other status code cases than 400.
In our case we got an example in which we would need the scimType on 403 error responses to let the client know what exactly of his action was forbidden which is done by a single keyword that must be parsed and translated into a localized human readable message.
SCIM does not define operations or additional attributes for this so the only way here is to rely on the scimType