### PR TITLE
Update AbstractResource.java to support RFC 8259

### DIFF
--- a/modules/charon-impl/src/main/java/org/wso2/charon3/impl/provider/resources/AbstractResource.java
+++ b/modules/charon-impl/src/main/java/org/wso2/charon3/impl/provider/resources/AbstractResource.java
@@ -49,8 +49,12 @@ public class AbstractResource implements Microservice {
 
     //identify the input format
     public boolean isValidInputFormat(String format) {
+        if(format == null){
+            return true;
+        }
+        
         String mediaType = format.split(";")[0];
-        if (mediaType == null || "*/*".equals(mediaType) ||
+        if ("*/*".equals(mediaType) ||
                 mediaType.equalsIgnoreCase(SCIMProviderConstants.APPLICATION_JSON)
                 || mediaType.equalsIgnoreCase(SCIMProviderConstants.APPLICATION_SCIM_JSON)) {
             return true;

--- a/modules/charon-impl/src/main/java/org/wso2/charon3/impl/provider/resources/AbstractResource.java
+++ b/modules/charon-impl/src/main/java/org/wso2/charon3/impl/provider/resources/AbstractResource.java
@@ -49,9 +49,10 @@ public class AbstractResource implements Microservice {
 
     //identify the input format
     public boolean isValidInputFormat(String format) {
-        if (format == null || "*/*".equals(format) ||
-                format.equalsIgnoreCase(SCIMProviderConstants.APPLICATION_JSON)
-                || format.equalsIgnoreCase(SCIMProviderConstants.APPLICATION_SCIM_JSON)) {
+        String mediaType = format.split(";")[0];
+        if (mediaType == null || "*/*".equals(mediaType) ||
+                mediaType.equalsIgnoreCase(SCIMProviderConstants.APPLICATION_JSON)
+                || mediaType.equalsIgnoreCase(SCIMProviderConstants.APPLICATION_SCIM_JSON)) {
             return true;
         } else {
             return false;


### PR DESCRIPTION
RFC 8259 Section 8.1 specifies that the header "charset=utf-8" should be accepted or ignored for open-networked systems. Currently it is denied by input validation. This small edit allows input validation to ignore it.

## Purpose
Resolves issue #6996 in product-is repo.

## Goals
Ignores "charset=utf8" to meet RFC requirement and allows third party systems that follow the RFC to work with the SCIMv2 api.

## Approach
Split the format string into a mediatype string and used that.


## Automation tests
@Test
public void mediatype(){
    String format = "application/scim+json; charset=utf-8";
    String mediaType = format.split(";")[0];
    System.out.println(mediaType);
    format = "application/scim+json";
    mediaType = format.split(";")[0];
    System.out.println(mediaType);
}

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes