### PR TITLE
Extract the size from the filtered group list

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
@@ -412,7 +412,7 @@ public class GroupResourceManager extends AbstractResourceManager {
         if (tempList == null) {
             tempList = Collections.emptyList();
         } else {
-            if (tempList.size() > 1) {
+            if (tempList.size() >= 1) {
                 if (tempList.get(0) instanceof Integer) {
                     totalResults = (int) tempList.get(0);
                     tempList.remove(0);


### PR DESCRIPTION
## Purpose
Fix https://github.com/wso2/product-is/issues/7520

## Approach
As per the implementation [1], the first element of the filtered list of groups contains the number of elements in the list. Therefore when retrieving the groups, first we need to remove the first element which only contains a number.

[1] https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/blob/master/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java#L2166