### PR TITLE
Set SCIM Group's display name as required

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMSchemaDefinitions.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMSchemaDefinitions.java
@@ -875,7 +875,7 @@ public class SCIMSchemaDefinitions {
                 SCIMAttributeSchema.createSCIMAttributeSchema(SCIMConstants.GroupSchemaConstants.DISPLAY_NAME_URI,
                         SCIMConstants.GroupSchemaConstants.DISPLAY_NAME,
                         SCIMDefinitions.DataType.STRING, false, SCIMConstants.GroupSchemaConstants.DISPLAY_NAME_DESC,
-                        false, false,
+                        true, false,
                         SCIMDefinitions.Mutability.READ_WRITE, SCIMDefinitions.Returned.DEFAULT,
                         SCIMDefinitions.Uniqueness.NONE, null, null, null);
 


### PR DESCRIPTION
## Purpose
> Fixes https://github.com/wso2/product-is/issues/7660.
- The display name attribute of the SCIM group resource is a [required attribute[1]](https://tools.ietf.org/html/rfc7643#section-4.2). This PR fixes the code to be compatible with that.