### PR TITLE
Patch replace operation changed to support permission changes.

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONDecoder.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONDecoder.java
@@ -370,7 +370,14 @@ public class JSONDecoder {
         }
     }
 
-    private List<String> toList(JSONArray array) throws JSONException {
+    /**
+     * Converts a JSONArray to a List<String>.
+     *
+     * @param array             JSONArray object.
+     * @return                  List<String> of the JSONArray object.
+     * @throws JSONException    Error when creating List from JSONArray.
+     */
+    public List<String> toList(JSONArray array) throws JSONException {
 
         List<String> list = new ArrayList<>();
         for (int i = 0; i < array.length(); i++) {


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/wso2/product-is/issues/10103

## Approach
> Role permissions can be udpated via the roles endpoint only using a `PATCH` request with the `replace` operation. The specification of the permissions attribute deviates from the general schema used for other attributes. Hence, permissions do not get updated by the general methods. This PR adds checks for identifying role permission update operations and updates the role attributes accordingly.

## Related PRs
> https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/300