### PR TITLE
Pagination default count constants added to CharonConfiguration

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/config/CharonConfiguration.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/config/CharonConfiguration.java
@@ -144,6 +144,7 @@ public class CharonConfiguration implements Configuration {
         configMap.put(SCIMConfigConstants.MAX_RESULTS, maxResults);
         configMap.put(SCIMConfigConstants.PATCH, patchSupport);
         configMap.put(SCIMConfigConstants.AUTHENTICATION_SCHEMES, authenticationSchemes);
+        configMap.put(SCIMConfigConstants.PAGINATION_DEFAULT_COUNT, count);
         return  configMap;
     }
 

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/config/SCIMConfigConstants.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/config/SCIMConfigConstants.java
@@ -46,6 +46,7 @@ public class SCIMConfigConstants {
     public static final String MAX_RESULTS = "maxResults";
     public static final String AUTHENTICATION_SCHEMES = "authenticationSchemes";
     public static final String SCIM_SCHEMA_EXTENSION_CONFIG = "scim2-schema-extension.config";
+    public static final String PAGINATION_DEFAULT_COUNT = "pagination-default-count";
 
 
 }


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/wso2/product-is/issues/9859

## Approach
> The SCIM2 .search request fails for all (Users, Groups, Roles) endpoints when no count attribute is declared in the request body. Ideally, when the count attribute is not specified, the default pagination value must be used when returning results. The `pagination-default-count` was not being read properly from the `charon-config.xml` file. This PR adds the relevant constants needed and adds the value to the config object.

## Related PRs
> Merge with https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/301