### PR TITLE
Fix sub attribute filtering for SCIM extended attributes

### DIFF
--- a/modules/charon-core/pom.xml
+++ b/modules/charon-core/pom.xml
@@ -59,6 +59,11 @@
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -112,6 +117,16 @@
                             org.slf4j.*,
                         </Import-Package>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
+                <configuration>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
+                    </suiteXmlFiles>
                 </configuration>
             </plugin>
         </plugins>

--- a/modules/charon-core/src/test/java/org/wso2/charon3/core/utils/AttributeUtilTest.java
+++ b/modules/charon-core/src/test/java/org/wso2/charon3/core/utils/AttributeUtilTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.charon3.core.utils;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.charon3.core.exceptions.BadRequestException;
+import org.wso2.charon3.core.schema.AttributeSchema;
+import org.wso2.charon3.core.schema.SCIMAttributeSchema;
+import org.wso2.charon3.core.schema.SCIMResourceTypeSchema;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.wso2.charon3.core.schema.SCIMDefinitions.DataType.COMPLEX;
+import static org.wso2.charon3.core.schema.SCIMDefinitions.DataType.STRING;
+import static org.wso2.charon3.core.schema.SCIMDefinitions.Mutability.READ_WRITE;
+import static org.wso2.charon3.core.schema.SCIMDefinitions.Returned.DEFAULT;
+import static org.wso2.charon3.core.schema.SCIMDefinitions.Uniqueness.NONE;
+
+/**
+ * Test class of AttributeUtil.
+ */
+public class AttributeUtilTest {
+
+    @DataProvider(name = "dataForQueryParamEncoding")
+    public Object[][] dataToGetAttributeURI() {
+
+        List<String> schemasList = new ArrayList<>();
+        schemasList.add("urn:ietf:params:scim:schemas:core:2.0:User");
+        schemasList.add("urn:ietf:params:scim:schemas:extension:enterprise:2.0:User");
+        AttributeSchema subSubAttributeSchema =
+                SCIMAttributeSchema.createSCIMAttributeSchema(
+                        "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:addresses.city",
+                        "city", STRING, false, "", false, false,
+                        READ_WRITE, DEFAULT, NONE, null, null, null);
+        ArrayList<AttributeSchema> subSubAttributeSchemaList = new ArrayList<>();
+        subSubAttributeSchemaList.add(subSubAttributeSchema);
+        AttributeSchema subAttributeSchema1 =
+                SCIMAttributeSchema.createSCIMAttributeSchema(
+                        "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:addresses",
+                        "addresses", COMPLEX, false, "", false, false,
+                        READ_WRITE, DEFAULT, NONE, null, null,
+                        subSubAttributeSchemaList);
+        AttributeSchema subAttributeSchema2 =
+                SCIMAttributeSchema.createSCIMAttributeSchema(
+                        "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department",
+                        "department", STRING, false, "", false, false,
+                        READ_WRITE, DEFAULT, NONE, null, null, null);
+        AttributeSchema subAttributeSchema3 =
+                SCIMAttributeSchema.createSCIMAttributeSchema(
+                        "urn:ietf:params:scim:schemas:core:2.0:User:emails.value",
+                        "value", STRING, false, "", false, false,
+                        READ_WRITE, DEFAULT, NONE, null, null, null);
+        ArrayList<AttributeSchema> subAttributeSchemaList = new ArrayList<>();
+        subAttributeSchemaList.add(subAttributeSchema1);
+        subAttributeSchemaList.add(subAttributeSchema2);
+        subAttributeSchemaList.add(subAttributeSchema3);
+        ArrayList<AttributeSchema> subAttributeSchemaList1 = new ArrayList<>();
+        subAttributeSchemaList1.add(subAttributeSchema3);
+        AttributeSchema attributeSchema1 =
+                SCIMAttributeSchema.createSCIMAttributeSchema(
+                        "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
+                        "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User", COMPLEX,
+                        false, "", false, false,
+                        READ_WRITE, DEFAULT, NONE, null, null, subAttributeSchemaList);
+        AttributeSchema attributeSchema2 =
+                SCIMAttributeSchema.createSCIMAttributeSchema(
+                        "urn:ietf:params:scim:schemas:core:2.0:User:emails",
+                        "emails", COMPLEX,
+                        true, "", false, false,
+                        READ_WRITE, DEFAULT, NONE, null, null, subAttributeSchemaList1);
+        SCIMResourceTypeSchema scimResourceTypeSchema =
+                SCIMResourceTypeSchema.createSCIMResourceSchema(schemasList, attributeSchema1, attributeSchema2);
+
+        return new Object[][]{
+
+                {"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.addresses.city",
+                        scimResourceTypeSchema,
+                        "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:addresses.city"},
+                {"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:addresses.city",
+                        scimResourceTypeSchema,
+                        "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:addresses.city"},
+                {"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department",
+                        scimResourceTypeSchema,
+                        "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department"},
+                {"urn:ietf:params:scim:schemas:core:2.0:User:emails.home",
+                        scimResourceTypeSchema,
+                        "urn:ietf:params:scim:schemas:core:2.0:User:emails.home"},
+                {"emails.home", scimResourceTypeSchema,
+                        "urn:ietf:params:scim:schemas:core:2.0:User:emails.home"}
+        };
+    }
+
+    @Test(dataProvider = "dataForQueryParamEncoding")
+    public void testGetAttributeURI(String attributeName, SCIMResourceTypeSchema schema,
+                                    String expectedAttributeURI) throws BadRequestException {
+
+        String attributeURI = AttributeUtil.getAttributeURI(attributeName, schema);
+        Assert.assertEquals(attributeURI, expectedAttributeURI);
+    }
+}

--- a/modules/charon-core/src/test/resources/testng.xml
+++ b/modules/charon-core/src/test/resources/testng.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="charon-core-test-suite">
+    <test name="charon-core-endpoint-test-all">
+        <classes>
+            <class name="org.wso2.charon3.core.utils.AttributeUtilTest"/>
+        </classes>
+    </test>
+</suite>

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,12 @@
                 <artifactId>log4j-1.2-api</artifactId>
                 <version>${log4j.api.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.testng</groupId>
+                <artifactId>testng</artifactId>
+                <version>${testng.version}</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -313,11 +319,13 @@
 
         <slf4j.version>1.7.26</slf4j.version>
         <maven.findbugsplugin.version>3.0.4</maven.findbugsplugin.version>
+        <maven.surefire.plugin.version>2.22.0</maven.surefire.plugin.version>
 
         <!-- Pax Logging Version -->
         <pax.logging.api.version>1.10.1</pax.logging.api.version>
 
         <log4j.api.version>2.12.0</log4j.api.version>
+        <testng.version>6.9.10</testng.version>
     </properties>
 
 </project>


### PR DESCRIPTION
Description

Resolves: wso2/product-is#11026

With this PR following to scenarios were fixed.
**Scenario 01:** Unique attribute names like urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:class.leader
In the previous code, it is checking subAttributeSchema.getURI().equals(attributeName). With this PR, it is corrected to subSubAttributeSchema.getURI().equals(attributeName).

**Scenario 02:** Attribute name already exists in another schema.(Ex: urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:addresses.city)
As addresses attribute name already exists in another schema (urn:ietf:params:scim:schemas:core:2.0:User:addresses), the logic becomes true and it assumes this extend attribute is part of the core schema. Then it generates a messy attribute URI as urn:ietf:params:scim:schemas:core:2.0:User:addresses.0:User:addresses.city.
With this PR, it validates whether the attribute is from scim2 extension schema by checking the ATTRIBUTE_EXTENSION_SCHEMA_PREFIX, if so check the attribute name contains the URI of the attribute schema, else check the attribute name contains URI of the attribute schema for the extended attributes.

This fix contains the unit tests.