### PR TITLE
Fix incorrect location attribute in SCIM 2 response when patching groups using bulk post

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
@@ -770,7 +770,7 @@ public class GroupResourceManager extends AbstractResourceManager {
 
                 Map<String, String> httpHeaders = new HashMap<>();
                 httpHeaders.put(SCIMConstants.LOCATION_HEADER,
-                        getResourceEndpointURL(SCIMConstants.USER_ENDPOINT) + "/" + updatedGroup.getId());
+                        getResourceEndpointURL(SCIMConstants.GROUP_ENDPOINT) + "/" + updatedGroup.getId());
                 httpHeaders.put(SCIMConstants.CONTENT_TYPE_HEADER, SCIMConstants.APPLICATION_JSON);
 
                 return new SCIMResponse(ResponseCodeConstants.CODE_OK, encodedGroup, httpHeaders);


### PR DESCRIPTION
## Purpose
> This PR fixes the incorrect location attribute in response when patching groups using bulk post
Resolves : https://github.com/wso2/product-is/issues/11034