### PR TITLE
Fix Filters with parentheses not working

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/codeutils/FilterTreeManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/codeutils/FilterTreeManager.java
@@ -46,7 +46,7 @@ public class FilterTreeManager {
     private String symbol;
     private Node root;
     private SCIMResourceTypeSchema schema;
-
+    
     public FilterTreeManager(String filterString, SCIMResourceTypeSchema schema) throws IOException {
 
         String encodedString = URLEncoder.encode(filterString, "UTF-8");
@@ -181,7 +181,7 @@ public class FilterTreeManager {
         } else {
             if (!(symbol.equals(String.valueOf(SCIMConstants.OperationalConstants.RIGHT)))) {
                 ExpressionNode expressionNode = new ExpressionNode();
-                validateAndBuildFilterExpression(symbol, expressionNode);
+                validateAndBuildFilterExpression(removeFilterParenthesesAndQuotes(symbol), expressionNode);
                 root = expressionNode;
                 symbol = nextSymbol();
             } else {
@@ -324,5 +324,9 @@ public class FilterTreeManager {
             decodedValue = decodedValue.replaceFirst("'", "").replaceAll("'$", "");
         }
         return decodedValue;
+    }
+
+    private String removeFilterParenthesesAndQuotes(String filterString) {
+        return filterString.replace("(", "").replace(")", "").replace("\"", "").replace("'", "");
     }
 }


### PR DESCRIPTION
## Purpose
Resolves issue https://github.com/wso2/charon/issues/273

## Goals
Remove parentheses and quotes from filter tree for Root Node operands.

## Approach
Parentheses and quotes in attribute names/values not allowed in expression node to process filtered requests. 
See filtering - https://tools.ietf.org/html/rfc7644#section-3.4.2.2

## User stories
https://github.com/wso2/charon/issues/273

## Release note
Fix expression node containing unnecessary parenthesis or quotes in value string cause invalid schema attribute value response.

## Documentation
N/A - No change to documented behavior.

## Training
N/A

## Certification
N/A - No change to documented behavior.

## Marketing
N/A - No change to documented behavior.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
JDK 8.x
 
## Learning
N/A