### PR TITLE
Resolve root config from the attribute name

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/config/SCIMUserSchemaExtensionBuilder.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/config/SCIMUserSchemaExtensionBuilder.java
@@ -15,6 +15,7 @@
  */
 package org.wso2.charon3.core.config;
 
+import org.apache.commons.lang.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -43,7 +44,8 @@ public class SCIMUserSchemaExtensionBuilder {
     // configuration map
     private static Map<String, ExtensionAttributeSchemaConfig> extensionConfig =
             new HashMap<String, ExtensionAttributeSchemaConfig>();
-    // extension root attribute name
+    // Extension root attribute name.
+    String extensionRootAttributeName = null;
     String extensionRootAttributeURI = null;
     // built schema map
     private static Map<String, AttributeSchema> attributeSchemas = new HashMap<String, AttributeSchema>();
@@ -110,6 +112,7 @@ public class SCIMUserSchemaExtensionBuilder {
                  */
                 if (index == attributeConfigArray.length() - 1) {
                     extensionRootAttributeURI = schemaAttributeConfig.getURI();
+                    extensionRootAttributeName = schemaAttributeConfig.getName();
                 }
             }
             inputStream.close();
@@ -136,6 +139,9 @@ public class SCIMUserSchemaExtensionBuilder {
 
     private boolean isRootConfig(ExtensionAttributeSchemaConfig config) {
 
+        if (StringUtils.isNotBlank(extensionRootAttributeName)) {
+            return extensionRootAttributeName.equals(config.getName());
+        }
         return config.getURI().equals(config.getName());
     }
 

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/config/SCIMUserSchemaExtensionBuilder.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/config/SCIMUserSchemaExtensionBuilder.java
@@ -139,10 +139,8 @@ public class SCIMUserSchemaExtensionBuilder {
 
     private boolean isRootConfig(ExtensionAttributeSchemaConfig config) {
 
-        if (StringUtils.isNotBlank(extensionRootAttributeName)) {
-            return extensionRootAttributeName.equals(config.getName());
-        }
-        return config.getURI().equals(config.getName());
+        return StringUtils.isNotBlank(extensionRootAttributeName) &&
+                extensionRootAttributeName.equals(config.getName());
     }
 
     /*


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/11418

### Approach 
Identify the root config from the root attribute name instead of root attribute URI. This will resolve when the root attribute name is different to the root attribute URI.