### PR TITLE
Handle processing of required/excluded attributes for create Group action

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
@@ -159,7 +159,7 @@ public class GroupResourceManager extends AbstractResourceManager {
             String encodedGroup;
             Map<String, String> httpHeaders = new HashMap<String, String>();
             if (createdGroup != null) {
-
+                ServerSideValidator.validateReturnedAttributes(createdGroup, attributes, excludeAttributes);
                 encodedGroup = encoder.encodeSCIMObject(createdGroup);
                 //add location header
                 httpHeaders.put(SCIMConstants.LOCATION_HEADER, getResourceEndpointURL(


### PR DESCRIPTION
## Purpose
For create (POST) Group Resource action the attributes specified in `attributes` or `excudedAttributes` are ignored and the response sent back contains all the attributes.

## Goals
Process `attributes` or `excudedAttributes` patameters for create (POST) Group Resource action.

## Approach
In the same way as for update (PUT) Group Resource action attributes are processed.

## Release note
Create Group Resource action now handles `attributes` and `excudedAttributes` correctly.

## Automation tests
 - Unit tests 
   > currently this part is not yet covered so no tests to extend

## Learning
https://tools.ietf.org/html/rfc7644#section-3.4.2.5