### PR TITLE
Allow /Me API to be optional by supplying NotImplementedException

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/extensions/UserManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/extensions/UserManager.java
@@ -124,10 +124,10 @@ public interface UserManager {
     }
 
     public User getMe(String userName, Map<String, Boolean> requiredAttributes)
-            throws CharonException, BadRequestException, NotFoundException;
+            throws CharonException, BadRequestException, NotFoundException, NotImplementedException;
 
     public User createMe(User user, Map<String, Boolean> requiredAttributes)
-            throws CharonException, ConflictException, BadRequestException;
+            throws CharonException, ConflictException, BadRequestException, NotImplementedException;
 
     public void deleteMe(String userName)
             throws NotFoundException, CharonException, NotImplementedException, BadRequestException;

--- a/modules/charon-core/src/test/java/org/wso2/charon3/core/protocol/endpoints/MeResourceManagerTest.java
+++ b/modules/charon-core/src/test/java/org/wso2/charon3/core/protocol/endpoints/MeResourceManagerTest.java
@@ -320,7 +320,7 @@ public class MeResourceManagerTest {
     @Test(dataProvider = "dataForGetUserSuccess")
     public void testGetUserSuccess(String id, String name, String attributes,
                                    String excludeAttributes, Object objectUser)
-            throws CharonException, BadRequestException, NotFoundException {
+            throws CharonException, BadRequestException, NotFoundException, NotImplementedException {
 
         User user = (User) objectUser;
 
@@ -367,7 +367,7 @@ public class MeResourceManagerTest {
 
     @Test(dataProvider = "dataForGetUserNotFoundException")
     public void testGetUserNotFoundException(String name, String attributes, String excludeAttributes)
-            throws CharonException, BadRequestException, NotFoundException {
+            throws CharonException, BadRequestException, NotFoundException, NotImplementedException {
 
         SCIMResourceTypeSchema schema = SCIMResourceSchemaManager.getInstance().getUserResourceSchema();
         Map<String, Boolean> requiredAttributes = ResourceManagerUtil.getOnlyRequiredAttributesURIs(
@@ -396,7 +396,7 @@ public class MeResourceManagerTest {
     @Test(dataProvider = "dataForGetCharonException")
     public void testGetUserCharonException(String name, String attributes, String excludeAttributes,
                                            int expectedScimResponseStatus)
-            throws CharonException, BadRequestException, NotFoundException {
+            throws CharonException, BadRequestException, NotFoundException, NotImplementedException {
 
         SCIMResourceTypeSchema schema = SCIMResourceSchemaManager.getInstance().getUserResourceSchema();
         Map<String, Boolean> requiredAttributes = ResourceManagerUtil.getOnlyRequiredAttributesURIs(
@@ -425,7 +425,7 @@ public class MeResourceManagerTest {
     @Test(dataProvider = "dataForGetBadRequestException")
     public void testGetUserBadRequestException(String name, String attributes, String excludeAttributes,
                                                int expectedScimResponseStatus)
-            throws CharonException, BadRequestException, NotFoundException {
+            throws CharonException, BadRequestException, NotFoundException, NotImplementedException {
 
         SCIMResourceTypeSchema schema = SCIMResourceSchemaManager.getInstance().getUserResourceSchema();
         Map<String, Boolean> requiredAttributes = ResourceManagerUtil.getOnlyRequiredAttributesURIs(
@@ -453,7 +453,8 @@ public class MeResourceManagerTest {
 
     @Test(dataProvider = "dataForTestCreateUserSuccess")
     public void testCreateUserSuccess(String scimObjectString, String attributes, String excludeAttributes)
-            throws BadRequestException, CharonException, InternalErrorException, ConflictException {
+            throws BadRequestException, CharonException, InternalErrorException, ConflictException,
+            NotImplementedException {
 
         User user = getNewUser();
         abstractResourceManager.when(() -> AbstractResourceManager.getResourceEndpointURL(SCIMConstants.USER_ENDPOINT))
@@ -486,7 +487,7 @@ public class MeResourceManagerTest {
     public void testCreateProvidedUserManagerHandlerIsNull(String scimObjectString, String attributes,
                                                            String excludeAttributes, Object objectUser,
                                                            int expectedScimResponseStatus)
-            throws ConflictException, BadRequestException, CharonException {
+            throws ConflictException, BadRequestException, CharonException, NotImplementedException {
 
         User user = (User) objectUser;
 
@@ -513,7 +514,7 @@ public class MeResourceManagerTest {
     @Test(dataProvider = "dataForTestCreatedUserResourceIsNull")
     public void testCreatedUserResourceIsNull(String scimObjectString, String attributes,
                                               String excludeAttributes, int expectedScimResponseStatus)
-            throws ConflictException, BadRequestException, CharonException {
+            throws ConflictException, BadRequestException, CharonException, NotImplementedException {
 
         abstractResourceManager.when(() -> AbstractResourceManager.getResourceEndpointURL(SCIMConstants.USER_ENDPOINT))
                 .thenReturn(SCIM2_ME_ENDPOINT);
@@ -539,7 +540,7 @@ public class MeResourceManagerTest {
     @Test(dataProvider = "dataForTestCreateBadRequestException")
     public void testCreateBadRequestException(String scimObjectString, String attributes,
                                               String excludeAttributes, int expectedScimResponseStatus)
-            throws ConflictException, BadRequestException, CharonException {
+            throws ConflictException, BadRequestException, CharonException, NotImplementedException {
 
         abstractResourceManager.when(() -> AbstractResourceManager.getResourceEndpointURL(SCIMConstants.USER_ENDPOINT))
                 .thenReturn(SCIM2_ME_ENDPOINT);
@@ -563,7 +564,7 @@ public class MeResourceManagerTest {
     @Test(dataProvider = "dataForTestCreateUserConflictException")
     public void testCreateUserConflictException(String scimObjectString, String attributes,
                                                 String excludeAttributes, int expectedScimResponseStatus)
-            throws ConflictException, BadRequestException, CharonException {
+            throws ConflictException, BadRequestException, CharonException, NotImplementedException {
 
         abstractResourceManager.when(() -> AbstractResourceManager.getResourceEndpointURL(SCIMConstants.USER_ENDPOINT))
                 .thenReturn(SCIM2_ME_ENDPOINT);
@@ -893,7 +894,7 @@ public class MeResourceManagerTest {
     @Test(dataProvider = "dataForTestUpdateWithPUTBadRequestException")
     public void testUpdateWithPUTBadRequestException(String userName, String scimObjectString, String
             attributes, String excludeAttributes, int expectedScimResponseStatus)
-            throws CharonException, BadRequestException, NotFoundException {
+            throws CharonException, BadRequestException, NotFoundException, NotImplementedException {
 
         SCIMResourceTypeSchema schema = SCIMResourceSchemaManager.getInstance().getUserResourceSchema();
 
@@ -1162,7 +1163,7 @@ public class MeResourceManagerTest {
     public void testUpdateWithPATCHBadRequestException(String existingId, String scimObjectString,
                                                        String attributes, String excludeAttributes,
                                                        int expectedScimResponseStatus)
-            throws CharonException, BadRequestException, NotFoundException {
+            throws CharonException, BadRequestException, NotFoundException, NotImplementedException {
 
         SCIMResourceTypeSchema schema = SCIMResourceSchemaManager.getInstance().getUserResourceSchema();
 
@@ -1199,7 +1200,7 @@ public class MeResourceManagerTest {
     public void testUpdateWithPATCHInternalErrorException(String existingId, String scimObjectString,
                                                           String attributes, String excludeAttributes,
                                                           int expectedScimResponseStatus)
-            throws CharonException, BadRequestException, NotFoundException {
+            throws CharonException, BadRequestException, NotFoundException, NotImplementedException {
 
         SCIMResourceTypeSchema schema = SCIMResourceSchemaManager.getInstance().getUserResourceSchema();
 

--- a/modules/charon-core/src/test/java/org/wso2/charon3/core/protocol/endpoints/MeResourceManagerTest.java
+++ b/modules/charon-core/src/test/java/org/wso2/charon3/core/protocol/endpoints/MeResourceManagerTest.java
@@ -488,7 +488,8 @@ public class MeResourceManagerTest {
     public void testCreateProvidedUserManagerHandlerIsNull(String scimObjectString, String attributes,
                                                            String excludeAttributes, Object objectUser,
                                                            int expectedScimResponseStatus)
-            throws ConflictException, BadRequestException, CharonException, ForbiddenException, NotImplementedException {
+            throws ConflictException, BadRequestException, CharonException, ForbiddenException,
+            NotImplementedException {
 
         User user = (User) objectUser;
 
@@ -515,7 +516,8 @@ public class MeResourceManagerTest {
     @Test(dataProvider = "dataForTestCreatedUserResourceIsNull")
     public void testCreatedUserResourceIsNull(String scimObjectString, String attributes,
                                               String excludeAttributes, int expectedScimResponseStatus)
-            throws ConflictException, BadRequestException, CharonException, ForbiddenException, NotImplementedException {
+            throws ConflictException, BadRequestException, CharonException, ForbiddenException,
+            NotImplementedException {
 
         abstractResourceManager.when(() -> AbstractResourceManager.getResourceEndpointURL(SCIMConstants.USER_ENDPOINT))
                 .thenReturn(SCIM2_ME_ENDPOINT);
@@ -541,7 +543,8 @@ public class MeResourceManagerTest {
     @Test(dataProvider = "dataForTestCreateBadRequestException")
     public void testCreateBadRequestException(String scimObjectString, String attributes,
                                               String excludeAttributes, int expectedScimResponseStatus)
-            throws ConflictException, BadRequestException, CharonException, ForbiddenException, NotImplementedException {
+            throws ConflictException, BadRequestException, CharonException, ForbiddenException,
+            NotImplementedException {
 
         abstractResourceManager.when(() -> AbstractResourceManager.getResourceEndpointURL(SCIMConstants.USER_ENDPOINT))
                 .thenReturn(SCIM2_ME_ENDPOINT);
@@ -565,7 +568,8 @@ public class MeResourceManagerTest {
     @Test(dataProvider = "dataForTestCreateUserConflictException")
     public void testCreateUserConflictException(String scimObjectString, String attributes,
                                                 String excludeAttributes, int expectedScimResponseStatus)
-            throws ConflictException, BadRequestException, CharonException, ForbiddenException, NotImplementedException {
+            throws ConflictException, BadRequestException, CharonException, ForbiddenException,
+            NotImplementedException {
 
         abstractResourceManager.when(() -> AbstractResourceManager.getResourceEndpointURL(SCIMConstants.USER_ENDPOINT))
                 .thenReturn(SCIM2_ME_ENDPOINT);


### PR DESCRIPTION
## Purpose
Currently, not all the parts of /Me API allow responding with "not implemented" response. This contradicts with official specification.

## Goals
Extend interface of the API responsible for /Me API with `NotImplementedException`.

## Documentation
According to the specification https://datatracker.ietf.org/doc/html/rfc7644#section-3.11 there must be a way to respond with "not implemented" response for /Me requests