### PR TITLE
Change the default value CUSTOM_USER_SCHEMA_URI to "urn:scim:wso2:schema"

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMConstants.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMConstants.java
@@ -25,7 +25,7 @@ public class SCIMConstants {
     public static final String USER_CORE_SCHEMA_URI = "urn:ietf:params:scim:schemas:core:2.0:User";
     public static final String ENTERPRISE_USER_SCHEMA_URI =
             "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User";
-    public static final String CUSTOM_USER_SCHEMA_URI = "urn:scim:custom:schema";
+    public static final String CUSTOM_USER_SCHEMA_URI = "urn:scim:wso2:schema";
     public static final String GROUP_CORE_SCHEMA_URI = "urn:ietf:params:scim:schemas:core:2.0:Group";
     public static final String ROLE_SCHEMA_URI = "urn:ietf:params:scim:schemas:extension:2.0:Role";
     public static final String LISTED_RESOURCE_CORE_SCHEMA_URI = "urn:ietf:params:scim:api:messages:2.0:ListResponse";


### PR DESCRIPTION
## Purpose
This PR sent as a step of refactoring SCIM claims. CUSTOM_USER_SCHEMA_URI  value has changed  "urn:scim:wso2:schema".  When configuration is not present "urn:scim:wso2:schema" value will be present as default .

## Related PRs
[identity-inbound-provisioning-scim2/pull/365](https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/365)