### PR TITLE
Fix for patch request failure due to invalid required characteristic check

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/AbstractValidator.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/AbstractValidator.java
@@ -16,6 +16,7 @@
 package org.wso2.charon3.core.schema;
 
 
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.charon3.core.attributes.AbstractAttribute;
@@ -102,6 +103,15 @@ public abstract class AbstractValidator {
                                 String error = "Required sub attribute: " + subAttributeSchema.getName()
                                         + " is missing in the SCIM Attribute: " + attribute.getName();
                                 throw new BadRequestException(error, ResponseCodeConstants.INVALID_VALUE);
+                            } else if (attribute.getSubAttribute(
+                                    subAttributeSchema.getName()) instanceof SimpleAttribute) {
+                                // If the attributes updated with "", that check is happening here.
+                                if (StringUtils.isEmpty(((SimpleAttribute) attribute.getSubAttribute(
+                                        subAttributeSchema.getName())).getValue().toString())) {
+                                    String error = "Required sub attribute: " + subAttributeSchema.getName()
+                                            + " is missing in the SCIM Attribute: " + attribute.getName();
+                                    throw new BadRequestException(error, ResponseCodeConstants.INVALID_VALUE);
+                                }
                             }
                         } else if (attribute instanceof MultiValuedAttribute) {
                             List<Attribute> values =

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/PatchOperationUtil.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/PatchOperationUtil.java
@@ -45,7 +45,6 @@ import org.wso2.charon3.core.schema.AttributeSchema;
 import org.wso2.charon3.core.schema.SCIMConstants;
 import org.wso2.charon3.core.schema.SCIMDefinitions;
 import org.wso2.charon3.core.schema.SCIMResourceTypeSchema;
-import org.wso2.charon3.core.schema.ServerSideValidator;
 import org.wso2.charon3.core.utils.codeutils.ExpressionNode;
 import org.wso2.charon3.core.utils.codeutils.PatchOperation;
 
@@ -115,11 +114,8 @@ public class PatchOperationUtil {
 
             doPatchRemoveWithoutFilters(parts, oldResource);
         }
-        //validate the updated object
-        AbstractSCIMObject validatedResource =  ServerSideValidator.validateUpdatedSCIMObject
-                (copyOfOldResource, oldResource, schema);
-
-        return validatedResource;
+        // All changes have been applied to old resource.
+        return oldResource;
 
     }
 
@@ -745,10 +741,8 @@ public class PatchOperationUtil {
         } else {
             doPatchAddOnResource(operation, decoder, oldResource, copyOfOldResource, schema);
         }
-        // Validate the updated object.
-        AbstractSCIMObject validatedResource = ServerSideValidator
-                .validateUpdatedSCIMObject(copyOfOldResource, oldResource, schema);
-        return validatedResource;
+        // All changes have been applied to old resource.
+        return oldResource;
     }
 
     /**
@@ -1729,10 +1723,8 @@ public class PatchOperationUtil {
                         }
                     }
                 }
-                AbstractSCIMObject validatedResource = ServerSideValidator.validateUpdatedSCIMObject
-                        (copyOfOldResource, oldResource, schema);
-
-                return validatedResource;
+                // All changes have been applied to old resource.
+                return oldResource;
             } else  {
                 throw new CharonException("Error in getting the old resource.");
             }
@@ -1780,10 +1772,8 @@ public class PatchOperationUtil {
         } else {
             doPatchReplaceOnResource(oldResource, copyOfOldResource, schema, decoder, operation);
         }
-        //validate the updated object
-        AbstractSCIMObject validatedResource =  ServerSideValidator.validateUpdatedSCIMObject
-                (copyOfOldResource, oldResource, schema);
-        return validatedResource;
+        // All changes have been applied to old resource.
+        return oldResource;
     }
 
     /*
@@ -3602,15 +3592,13 @@ public class PatchOperationUtil {
                         oldResource.setAttribute(attributeHoldingSCIMObject.getAttributeList().get(attributeName));
                     }
                 }
-                AbstractSCIMObject validatedResource = ServerSideValidator.validateUpdatedSCIMObject
-                        (copyOfOldResource, oldResource, schema);
-
-                return validatedResource;
+                // All changes have been applied to old resource.
+                return oldResource;
             } else  {
                 throw new CharonException("Error in getting the old resource.");
             }
         } catch (BadRequestException | CharonException e) {
-            throw new CharonException("Error in performing the add operation", e);
+            throw new CharonException("Error in performing the replace operation", e);
         }
     }
 }


### PR DESCRIPTION
## Issue
https://github.com/wso2/product-is/issues/12439

## Reason
As per the specification https://datatracker.ietf.org/doc/html/rfc7644#page-34

**Each operation** against an attribute MUST be **compatible with the
   attribute's mutability and schema** as defined in Sections 2.2 and 2.3
   of [RFC7643].  For example, a client MUST NOT modify an attribute
   that has mutability "readOnly" or "immutable".  However, a client MAY
   "add" a value to an "immutable" attribute if the attribute had no
   previous value.  An operation that is not compatible with an
   attribute's mutability or schema SHALL return the appropriate HTTP
   response status code and a JSON detail error response as defined in
   Section 3.12.


   Each PATCH operation represents a single action to be applied to the
   same SCIM resource specified by the request URI.  Operations are
   applied sequentially in the order they appear in the array.  Each
   operation in the sequence is applied to the target resource; the
   resulting resource becomes the target of the next operation.
   **Evaluation continues until all operations are successfully applied or
   until an error condition is encountered**.

---------------------------------------------------------------------------------------------------------------
:white_check_mark: Therefore after each patch operation, we validate the updated object against the resource schema.
:x: Here the problem is we are evaluating whether the updated object contains all required attributes as per the Resource Schema.

:bulb: Ideally what should happen after one operation: Do the required attribute check against the updated resource, only for the attributes accountable with the particular operation.

:question: The problem of the ideal solution is identifying the correct attribute schema according to the patch operation payload. `add`, `replace`, `remove`  patch operations have different formats (with path/without path) and the attribute type check also need to be done.

So for the moment, this fix is introduced. We remove the required attribute check per each patch operation. Do it only after all patch operations in the request. So the validation happens before updating the resource in the DB.
Problems: 
:heavy_exclamation_mark:  Spec violation **Evaluation continues until all operations are successfully applied or
   until an error condition is encountered**, Do the check only after all patch operations in the request

