### PR TITLE
Patch request failure due to required characteristic check

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/PatchOperationUtil.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/PatchOperationUtil.java
@@ -116,8 +116,8 @@ public class PatchOperationUtil {
             doPatchRemoveWithoutFilters(parts, oldResource);
         }
         //validate the updated object
-        AbstractSCIMObject validatedResource =  ServerSideValidator.validateUpdatedSCIMObject
-                (copyOfOldResource, oldResource, schema);
+        AbstractSCIMObject validatedResource =
+                ServerSideValidator.validateUpdatedSCIMObject(copyOfOldResource, oldResource, schema, true);
 
         return validatedResource;
 
@@ -746,8 +746,8 @@ public class PatchOperationUtil {
             doPatchAddOnResource(operation, decoder, oldResource, copyOfOldResource, schema);
         }
         // Validate the updated object.
-        AbstractSCIMObject validatedResource = ServerSideValidator
-                .validateUpdatedSCIMObject(copyOfOldResource, oldResource, schema);
+        AbstractSCIMObject validatedResource =
+                ServerSideValidator.validateUpdatedSCIMObject(copyOfOldResource, oldResource, schema, true);
         return validatedResource;
     }
 
@@ -1729,8 +1729,8 @@ public class PatchOperationUtil {
                         }
                     }
                 }
-                AbstractSCIMObject validatedResource = ServerSideValidator.validateUpdatedSCIMObject
-                        (copyOfOldResource, oldResource, schema);
+                AbstractSCIMObject validatedResource =
+                        ServerSideValidator.validateUpdatedSCIMObject(copyOfOldResource, oldResource, schema, true);
 
                 return validatedResource;
             } else  {
@@ -1774,15 +1774,15 @@ public class PatchOperationUtil {
                 }
 
             } else {
-                    doPatchReplaceOnPathWithoutFilters(oldResource, schema, decoder, operation, parts);
+                doPatchReplaceOnPathWithoutFilters(oldResource, schema, decoder, operation, parts);
             }
 
         } else {
             doPatchReplaceOnResource(oldResource, copyOfOldResource, schema, decoder, operation);
         }
         //validate the updated object
-        AbstractSCIMObject validatedResource =  ServerSideValidator.validateUpdatedSCIMObject
-                (copyOfOldResource, oldResource, schema);
+        AbstractSCIMObject validatedResource =
+                ServerSideValidator.validateUpdatedSCIMObject(copyOfOldResource, oldResource, schema, true);
         return validatedResource;
     }
 
@@ -3602,15 +3602,15 @@ public class PatchOperationUtil {
                         oldResource.setAttribute(attributeHoldingSCIMObject.getAttributeList().get(attributeName));
                     }
                 }
-                AbstractSCIMObject validatedResource = ServerSideValidator.validateUpdatedSCIMObject
-                        (copyOfOldResource, oldResource, schema);
+                AbstractSCIMObject validatedResource =
+                        ServerSideValidator.validateUpdatedSCIMObject(copyOfOldResource, oldResource, schema, true);
 
                 return validatedResource;
             } else  {
                 throw new CharonException("Error in getting the old resource.");
             }
         } catch (BadRequestException | CharonException e) {
-            throw new CharonException("Error in performing the add operation", e);
+            throw new CharonException("Error in performing the replace operation", e);
         }
     }
 }


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/product-is/issues/12439
:white_check_mark: After each patch operation, we validate the updated object against the resource schema.
:x: Here the problem is we are evaluating whether the updated object contains all required attributes as per the Resource Schema.
:bulb: Ideally what should happen after one operation: Do the required attribute check against the updated resource, only for the attributes accountable with the particular operation.

The simple solution is https://github.com/wso2/charon/pull/356

In order to align with the spec   https://datatracker.ietf.org/doc/html/rfc7644#page-34
**Evaluation continues until all operations are successfully applied or
until an error condition is encountered**

we can do the check as follows.
After each patch operation, the attribute's required to check is done if a particular attribute **was available in the scim object before patch operation but not in the scim object after the patch operation**.