### PR TITLE
Add SCIM2 filtering support when filter value is OR, AND or NOT 

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/codeutils/FilterTreeManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/codeutils/FilterTreeManager.java
@@ -125,6 +125,23 @@ public class FilterTreeManager {
         if (!(concatenatedString.equals(""))) {
             tokenList.add(concatenatedString);
         }
+
+        String updatedString = "";
+
+        for (int token = 0; token < tokenList.size(); token++) {
+            String[] splitedToken = tokenList.get(token).split("\\s+");
+            if (splitedToken.length == 2 && !splitedToken[1].equalsIgnoreCase(SCIMConstants.OperationalConstants.PR)) {
+                updatedString += tokenList.get(token);
+                if (tokenList.get(token + 1).equalsIgnoreCase(SCIMConstants.OperationalConstants.AND) ||
+                        tokenList.get(token + 1).equalsIgnoreCase(SCIMConstants.OperationalConstants.OR) ||
+                        tokenList.get(token + 1).equalsIgnoreCase(SCIMConstants.OperationalConstants.NOT)) {
+                    updatedString += " " + tokenList.get(token + 1);
+                    tokenList.set(token, updatedString);
+                    tokenList.remove(token + 1);
+                }
+                updatedString = "";
+            }
+        }
     }
 
     /*

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/codeutils/FilterTreeManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/codeutils/FilterTreeManager.java
@@ -43,7 +43,7 @@ import java.util.regex.Pattern;
 public class FilterTreeManager {
 
     private StreamTokenizer input;
-    protected List<String> TokenList = null;
+    protected List<String> tokenList = null;
     private String symbol;
     private Node root;
     private SCIMResourceTypeSchema schema;
@@ -126,7 +126,7 @@ public class FilterTreeManager {
             tempTokenList.add(concatenatedString);
         }
 
-        TokenList = new ArrayList<String>();
+        tokenList = new ArrayList<String>();
         Boolean stringsConcatenated = false;
 
         for (int token = 0; token < tempTokenList.size(); token++) {
@@ -145,7 +145,7 @@ public class FilterTreeManager {
                     stringsConcatenated = true;
                 }
             }
-            TokenList.add(updatedString);
+            tokenList.add(updatedString);
         }
     }
 
@@ -341,12 +341,12 @@ public class FilterTreeManager {
      */
     public String nextSymbol() {
 
-        if (TokenList.size() == 0) {
+        if (tokenList.size() == 0) {
             //no tokens are present in the list anymore/at all
             return String.valueOf(-1);
         } else {
-            String value = TokenList.get(0);
-            TokenList.remove(0);
+            String value = tokenList.get(0);
+            tokenList.remove(0);
             return value;
         }
     }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/codeutils/FilterTreeManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/codeutils/FilterTreeManager.java
@@ -43,7 +43,7 @@ import java.util.regex.Pattern;
 public class FilterTreeManager {
 
     private StreamTokenizer input;
-    protected List<String> newTokenList = null;
+    protected List<String> TokenList = null;
     private String symbol;
     private Node root;
     private SCIMResourceTypeSchema schema;
@@ -77,7 +77,7 @@ public class FilterTreeManager {
         input.wordChars('/', '/');
         input.wordChars('%', '%');
 
-        List<String> tokenList = new ArrayList<String>();
+        List<String> tempTokenList = new ArrayList<String>();
         String concatenatedString = "";
         String decodedValue;
 
@@ -89,7 +89,7 @@ public class FilterTreeManager {
                         decodedValue.equalsIgnoreCase(SCIMConstants.OperationalConstants.NOT))) {
 
                     if (decodedValue.startsWith("(")) {
-                        tokenList.add("(");
+                        tempTokenList.add("(");
                         decodedValue = decodedValue.substring(1);
                     }
                     if (decodedValue.endsWith(")")) {
@@ -100,9 +100,9 @@ public class FilterTreeManager {
                         concatenatedString += " " + decodedValue;
 
                         concatenatedString = concatenatedString.trim();
-                        tokenList.add(concatenatedString);
+                        tempTokenList.add(concatenatedString);
                         concatenatedString = StringUtils.EMPTY;
-                        tokenList.add(")");
+                        tempTokenList.add(")");
                     } else {
                         // Remove quotes if there are starting and ending quotes.
                         decodedValue = removeStartingAndEndingQuotes(decodedValue);
@@ -112,10 +112,10 @@ public class FilterTreeManager {
                 } else {
                     concatenatedString = concatenatedString.trim();
                     if (!concatenatedString.equals("")) {
-                        tokenList.add(concatenatedString);
+                        tempTokenList.add(concatenatedString);
                         concatenatedString = "";
                     }
-                    tokenList.add(decodedValue);
+                    tempTokenList.add(decodedValue);
                 }
             } else if (input.ttype == '\"' || input.ttype == '\'') {
                 concatenatedString += " " + input.sval;
@@ -123,29 +123,29 @@ public class FilterTreeManager {
         }
         //Add to the list, if the filter is a simple filter
         if (!(concatenatedString.equals(""))) {
-            tokenList.add(concatenatedString);
+            tempTokenList.add(concatenatedString);
         }
 
-        newTokenList = new ArrayList<String>();
+        TokenList = new ArrayList<String>();
         Boolean stringsConcatenated = false;
 
-        for (int token = 0; token < tokenList.size(); token++) {
-            String updatedString = tokenList.get(token).trim();
+        for (int token = 0; token < tempTokenList.size(); token++) {
+            String updatedString = tempTokenList.get(token).trim();
             String[] splitedToken = updatedString.split("\\s+");
             if (stringsConcatenated) {
                 stringsConcatenated = false;
                 continue;
             }
             if (splitedToken.length == 2 && !splitedToken[1].equalsIgnoreCase(SCIMConstants.OperationalConstants.PR) &&
-                    (token + 1) < tokenList.size()) {
-                if (tokenList.get(token + 1).equalsIgnoreCase(SCIMConstants.OperationalConstants.AND) ||
-                        tokenList.get(token + 1).equalsIgnoreCase(SCIMConstants.OperationalConstants.OR) ||
-                        tokenList.get(token + 1).equalsIgnoreCase(SCIMConstants.OperationalConstants.NOT)) {
-                    updatedString += " " + tokenList.get(token + 1);
+                    (token + 1) < tempTokenList.size()) {
+                if (tempTokenList.get(token + 1).equalsIgnoreCase(SCIMConstants.OperationalConstants.AND) ||
+                        tempTokenList.get(token + 1).equalsIgnoreCase(SCIMConstants.OperationalConstants.OR) ||
+                        tempTokenList.get(token + 1).equalsIgnoreCase(SCIMConstants.OperationalConstants.NOT)) {
+                    updatedString += " " + tempTokenList.get(token + 1);
                     stringsConcatenated = true;
                 }
             }
-            newTokenList.add(updatedString);
+            TokenList.add(updatedString);
         }
     }
 
@@ -341,12 +341,12 @@ public class FilterTreeManager {
      */
     public String nextSymbol() {
 
-        if (newTokenList.size() == 0) {
+        if (TokenList.size() == 0) {
             //no tokens are present in the list anymore/at all
             return String.valueOf(-1);
         } else {
-            String value = newTokenList.get(0);
-            newTokenList.remove(0);
+            String value = TokenList.get(0);
+            TokenList.remove(0);
             return value;
         }
     }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/codeutils/FilterTreeManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/codeutils/FilterTreeManager.java
@@ -43,7 +43,7 @@ import java.util.regex.Pattern;
 public class FilterTreeManager {
 
     private StreamTokenizer input;
-    protected List<String> tokenList = null;
+    protected List<String> newTokenList = null;
     private String symbol;
     private Node root;
     private SCIMResourceTypeSchema schema;
@@ -77,7 +77,7 @@ public class FilterTreeManager {
         input.wordChars('/', '/');
         input.wordChars('%', '%');
 
-        tokenList = new ArrayList<String>();
+        List<String> tokenList = new ArrayList<String>();
         String concatenatedString = "";
         String decodedValue;
 
@@ -126,21 +126,26 @@ public class FilterTreeManager {
             tokenList.add(concatenatedString);
         }
 
-        String updatedString = "";
+        newTokenList = new ArrayList<String>();
+        Boolean stringsConcatenated = false;
 
         for (int token = 0; token < tokenList.size(); token++) {
-            String[] splitedToken = tokenList.get(token).split("\\s+");
-            if (splitedToken.length == 2 && !splitedToken[1].equalsIgnoreCase(SCIMConstants.OperationalConstants.PR)) {
-                updatedString += tokenList.get(token);
+            String updatedString = tokenList.get(token).trim();
+            String[] splitedToken = updatedString.split("\\s+");
+            if (stringsConcatenated) {
+                stringsConcatenated = false;
+                continue;
+            }
+            if (splitedToken.length == 2 && !splitedToken[1].equalsIgnoreCase(SCIMConstants.OperationalConstants.PR) &&
+                    (token + 1) < tokenList.size()) {
                 if (tokenList.get(token + 1).equalsIgnoreCase(SCIMConstants.OperationalConstants.AND) ||
                         tokenList.get(token + 1).equalsIgnoreCase(SCIMConstants.OperationalConstants.OR) ||
                         tokenList.get(token + 1).equalsIgnoreCase(SCIMConstants.OperationalConstants.NOT)) {
                     updatedString += " " + tokenList.get(token + 1);
-                    tokenList.set(token, updatedString);
-                    tokenList.remove(token + 1);
+                    stringsConcatenated = true;
                 }
-                updatedString = "";
             }
+            newTokenList.add(updatedString);
         }
     }
 
@@ -336,12 +341,12 @@ public class FilterTreeManager {
      */
     public String nextSymbol() {
 
-        if (tokenList.size() == 0) {
+        if (newTokenList.size() == 0) {
             //no tokens are present in the list anymore/at all
             return String.valueOf(-1);
         } else {
-            String value = tokenList.get(0);
-            tokenList.remove(0);
+            String value = newTokenList.get(0);
+            newTokenList.remove(0);
             return value;
         }
     }


### PR DESCRIPTION
Fix https://github.com/wso2/product-is/issues/12759

SCIM2 filtering was not working when `OR`, `AND` or `NOT` is added as a filter value. This happens since `OR`, `AND`, `NOT` are always considered as operations and adding as a new token. As a solution, if the expression is invalid, the next `OR`, `AND` or `NOT` token is added to the expression.

This is provided as a temporary solution. Proper fix is to integrate a parser to validate the syntax.
Issue created to track this: https://github.com/wso2/product-is/issues/12868