### PR TITLE
Cursor based pagination for SCIM resources phase 1

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/config/CharonConfiguration.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/config/CharonConfiguration.java
@@ -36,6 +36,7 @@ public class CharonConfiguration implements Configuration {
     private int maxPayLoadSize;
     private int maxResults;
     private ArrayList<Object[]> authenticationSchemes = new ArrayList<Object[]>();
+    private boolean cursorSupport;
 
     //default count value for pagination
     private int count;
@@ -76,6 +77,15 @@ public class CharonConfiguration implements Configuration {
     public void setFilterSupport(boolean supported, int maxResults) {
         this.filterSupport = supported;
         this.maxResults = maxResults;
+    }
+
+    /**
+     * Set cursor pagination support
+     * @param supported
+     */
+    public void setCursorPaginationSupport(boolean supported) {
+
+        this.cursorSupport = supported;
     }
 
     /*
@@ -145,6 +155,7 @@ public class CharonConfiguration implements Configuration {
         configMap.put(SCIMConfigConstants.PATCH, patchSupport);
         configMap.put(SCIMConfigConstants.AUTHENTICATION_SCHEMES, authenticationSchemes);
         configMap.put(SCIMConfigConstants.PAGINATION_DEFAULT_COUNT, count);
+        configMap.put(SCIMConfigConstants.CURSOR, cursorSupport);
         return  configMap;
     }
 

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/config/SCIMConfigConstants.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/config/SCIMConfigConstants.java
@@ -47,6 +47,7 @@ public class SCIMConfigConstants {
     public static final String AUTHENTICATION_SCHEMES = "authenticationSchemes";
     public static final String SCIM_SCHEMA_EXTENSION_CONFIG = "scim2-schema-extension.config";
     public static final String PAGINATION_DEFAULT_COUNT = "pagination-default-count";
+    public static final String CURSOR = "cursor";
 
 
 }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONDecoder.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONDecoder.java
@@ -830,7 +830,13 @@ public class JSONDecoder {
             searchRequest.setExcludedAttributes(excludedAttributes);
             searchRequest.setSchema((String) schemas.get(0));
             searchRequest.setCountStr(decodedJsonObj.optString(SCIMConstants.OperationalConstants.COUNT));
-            searchRequest.setStartIndexStr(decodedJsonObj.optString(SCIMConstants.OperationalConstants.START_INDEX));
+            if (!decodedJsonObj.optString(SCIMConstants.OperationalConstants.START_INDEX).equals("")) {
+                searchRequest.setStartIndexStr(
+                        decodedJsonObj.optString(SCIMConstants.OperationalConstants.START_INDEX));
+            }
+            if (decodedJsonObj.has(SCIMConstants.OperationalConstants.CURSOR)) {
+                searchRequest.setCursor(decodedJsonObj.optString(SCIMConstants.OperationalConstants.CURSOR));
+            }
             searchRequest.setDomainName(decodedJsonObj.optString(SCIMConstants.OperationalConstants.DOMAIN));
             searchRequest.setFilter(rootNode);
             if (!decodedJsonObj.optString(SCIMConstants.OperationalConstants.SORT_BY).equals("")) {

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONEncoder.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONEncoder.java
@@ -418,6 +418,10 @@ public class JSONEncoder {
         changePasswordObject.put(SCIMConstants.ServiceProviderConfigSchemaConstants.SUPPORTED,
                 config.get(SCIMConfigConstants.CHNAGE_PASSWORD));
 
+        JSONObject paginationObject = new JSONObject();
+        paginationObject.put(SCIMConstants.ServiceProviderConfigSchemaConstants.CURSOR,
+                config.get(SCIMConfigConstants.CURSOR));
+
         JSONArray authenticationSchemesArray = new JSONArray();
         ArrayList<Object[]> values = (ArrayList<Object[]>) config.get(SCIMConfigConstants.AUTHENTICATION_SCHEMES);
 
@@ -457,6 +461,8 @@ public class JSONEncoder {
                 etagObject);
         rootObject.put(SCIMConstants.ServiceProviderConfigSchemaConstants.AUTHENTICATION_SCHEMAS,
                 authenticationSchemesArray);
+        rootObject.put(SCIMConstants.ServiceProviderConfigSchemaConstants.PAGINATION,
+                paginationObject);
 
         return rootObject.toString();
 

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/extensions/UserManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/extensions/UserManager.java
@@ -24,6 +24,7 @@ import org.wso2.charon3.core.exceptions.NotFoundException;
 import org.wso2.charon3.core.exceptions.NotImplementedException;
 import org.wso2.charon3.core.objects.Group;
 import org.wso2.charon3.core.objects.User;
+import org.wso2.charon3.core.objects.plainobjects.Cursor;
 import org.wso2.charon3.core.objects.plainobjects.GroupsGetResponse;
 import org.wso2.charon3.core.objects.plainobjects.UsersGetResponse;
 import org.wso2.charon3.core.schema.AttributeSchema;
@@ -53,22 +54,44 @@ public interface UserManager {
             throws NotFoundException, CharonException, NotImplementedException, BadRequestException;
 
     /**
-     * List users with Get.
+     * List users with Get using offset pagination.
      *
-     * @param node               Node
-     * @param startIndex         Start Index
-     * @param count              Count
-     * @param sortBy             Sort by
-     * @param sortOrder          Sort order
-     * @param domainName         Domain name
-     * @param requiredAttributes Required user attributes
-     * @return Users with requested attributes
-     * @throws CharonException         Error while listing users
-     * @throws NotImplementedException Operation note implemented
-     * @throws BadRequestException     Bad request
+     * @param node               Tree node built based on the filtering conditions.
+     * @param startIndex         Start Index.
+     * @param count              Count.
+     * @param sortBy             Sort by.
+     * @param sortOrder          Sort order.
+     * @param domainName         Domain name.
+     * @param requiredAttributes Required user attributes.
+     * @return Users with requested attributes.
+     * @throws CharonException         Error while listing users.
+     * @throws NotImplementedException Operation note implemented.
+     * @throws BadRequestException     Bad request.
      */
     default UsersGetResponse listUsersWithGET(Node node, Integer startIndex, Integer count, String sortBy,
-                        String sortOrder, String domainName, Map<String, Boolean> requiredAttributes)
+                                         String sortOrder, String domainName, Map<String, Boolean> requiredAttributes)
+            throws CharonException, NotImplementedException, BadRequestException {
+
+        return null;
+    }
+
+    /**
+     * List users with Get using cursor pagination.
+     *
+     * @param node               Tree node built based on the filtering conditions.
+     * @param cursor             Cursor value for pagination and the Pagination direction.
+     * @param count              Count.
+     * @param sortBy             Sort by.
+     * @param sortOrder          Sort order.
+     * @param domainName         Domain name.
+     * @param requiredAttributes Required user attributes.
+     * @return Users with requested attributes.
+     * @throws CharonException         Error while listing users.
+     * @throws NotImplementedException Operation note implemented.
+     * @throws BadRequestException     Bad request.
+     */
+    default UsersGetResponse listUsersWithGET(Node node, Cursor cursor, Integer count, String sortBy, String sortOrder,
+                                              String domainName, Map<String, Boolean> requiredAttributes)
             throws CharonException, NotImplementedException, BadRequestException {
 
         return null;
@@ -86,7 +109,7 @@ public interface UserManager {
      */
     @Deprecated
     default UsersGetResponse listUsersWithGET(Node node, int startIndex, int count, String sortBy, String sortOrder,
-            String domainName, Map<String, Boolean> requiredAttributes)
+                                              String domainName, Map<String, Boolean> requiredAttributes)
             throws CharonException, NotImplementedException, BadRequestException {
 
         return null;
@@ -188,7 +211,7 @@ public interface UserManager {
      *
      * @param oldGroup
      * @param newGroup
-     *
+     * 
      * @throws NotImplementedException
      * @throws BadRequestException
      * @throws CharonException

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/ListedResource.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/ListedResource.java
@@ -131,6 +131,42 @@ public class ListedResource extends AbstractSCIMObject {
     }
 
     /**
+     * Setting the next cursor as an SCIM attribute.
+     *
+     * @param nextCursor  The base64 encoded JSON string, made up of the cursor value and the pagination direction.
+     */
+    public void setNextCursor(String nextCursor) {
+
+        if (!isAttributeExist(SCIMConstants.ListedResourceSchemaConstants.NEXT_CURSOR)) {
+            SimpleAttribute nextCursorAttribute =
+                    new SimpleAttribute(SCIMConstants.ListedResourceSchemaConstants.NEXT_CURSOR, nextCursor);
+            attributeList.put(SCIMConstants.ListedResourceSchemaConstants.NEXT_CURSOR, nextCursorAttribute);
+        } else {
+            SimpleAttribute nextCursorAttribute = ((SimpleAttribute) attributeList
+                    .get(SCIMConstants.ListedResourceSchemaConstants.NEXT_CURSOR));
+            nextCursorAttribute.setValue(nextCursor);
+        }
+    }
+
+    /**
+     * Setting the previous cursor as an SCIM attribute.
+     *
+     * @param previousCursor  The base64 encoded JSON string, made up of the cursor value and the pagination direction.
+     */
+    public void setPreviousCursor(String previousCursor) {
+
+        if (!isAttributeExist(SCIMConstants.ListedResourceSchemaConstants.PREVIOUS_CURSOR)) {
+            SimpleAttribute prevCursorAttribute =
+                    new SimpleAttribute(SCIMConstants.ListedResourceSchemaConstants.PREVIOUS_CURSOR, previousCursor);
+            attributeList.put(SCIMConstants.ListedResourceSchemaConstants.PREVIOUS_CURSOR, prevCursorAttribute);
+        } else {
+            SimpleAttribute previousCursorAttribute = ((SimpleAttribute) attributeList
+                    .get(SCIMConstants.ListedResourceSchemaConstants.PREVIOUS_CURSOR));
+            previousCursorAttribute.setValue(previousCursor);
+        }
+    }
+
+    /**
      * set the listed resources
      *
      * @param valueWithAttributes

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/plainobjects/Cursor.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/plainobjects/Cursor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.charon3.core.objects.plainobjects;
+
+/**
+ * This class representation can be used to create a cursor type object which carries direction and cursor value
+ * to be used in cursor-based pagination.
+ */
+public class Cursor {
+
+    private String cursorValue;
+    private String direction;
+
+    public Cursor (String cursorVal, String direction) {
+        this.cursorValue = cursorVal;
+        this.direction = direction;
+    }
+
+    public String getCursorValue() {
+
+        return cursorValue;
+    }
+
+    public void setCursorValue(String cursorValue) {
+
+        this.cursorValue = cursorValue;
+    }
+
+    public String getDirection() {
+
+        return direction;
+    }
+
+    public void setDirection(String direction) {
+
+        this.direction = direction;
+    }
+}

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/plainobjects/UsersGetResponse.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/plainobjects/UsersGetResponse.java
@@ -22,12 +22,20 @@ import org.wso2.charon3.core.objects.User;
 import java.util.List;
 
 /**
+<<<<<<< HEAD
  * This class representation can be used to create a UsersGetResponse type object which carries the total number of
  * users identified from the filter and the list of users returned for this request.
+=======
+ * This class representation can be used to create a UserGetResponse type object which carries the list of users,
+ * total number of users and optionally the previous and next cursor value.
+ *
+>>>>>>> Cursor based pagination for scim resources.
  */
 public class UsersGetResponse {
 
     private int totalUsers;
+    private String nextCursor;
+    private String previousCursor;
     private List<User> users;
 
     /**
@@ -39,6 +47,17 @@ public class UsersGetResponse {
         this.users = users;
     }
 
+    /**
+     * Constructor used to build a response object when using cursor pagination.
+     */
+    public UsersGetResponse(int totalUsers, String nextCursor, String previousCursor, List<User> users) {
+
+        this.totalUsers = totalUsers;
+        this.nextCursor = nextCursor;
+        this.previousCursor = previousCursor;
+        this.users = users;
+    }
+
     public int getTotalUsers() {
 
         return totalUsers;
@@ -47,6 +66,21 @@ public class UsersGetResponse {
     public void setTotalUsers(int totalUsers) {
 
         this.totalUsers = totalUsers;
+    }
+    public String getNextCursor() {
+        return nextCursor;
+    }
+
+    public void setNextCursor(String nextCursor) {
+        this.nextCursor = nextCursor;
+    }
+
+    public String getPrevCursor() {
+        return previousCursor;
+    }
+
+    public void setPrevCursor(String prevCursor) {
+        this.previousCursor = prevCursor;
     }
 
     public List<User> getUsers() {

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/SCIMResponse.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/SCIMResponse.java
@@ -28,6 +28,7 @@ public class SCIMResponse {
     //If there are any HTTP header parameters to be set in response other than response code,
     protected Map<String, String> headerParamMap;
 
+
     /*
      * Constructor with three params
      *

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/ResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/ResourceManager.java
@@ -78,24 +78,44 @@ public interface ResourceManager {
      */
     @Deprecated
     SCIMResponse listWithGET(UserManager userManager, String filter, int startIndex, int count, String sortBy,
-            String sortOrder, String domainName, String attributes, String excludeAttributes);
+                             String sortOrder, String domainName, String attributes, String excludeAttributes);
 
     /*
-     * Get resources
+     * Get resources.
      *
-     * @param userManager       User manager
-     * @param filter            Filter to be executed
-     * @param startIndexInt     Starting index value of the filter
-     * @param countInt          Number of required results
-     * @param sortBy            SortBy
-     * @param sortOrder         Sorting order
-     * @param domainName        Domain name
-     * @param attributes        Attributes in the request
-     * @param excludeAttributes Exclude attributes
-     * @return SCIM response
+     * @param userManager       User manager.
+     * @param filter            Filter to be executed.
+     * @param startIndexInt     Starting index value of the filter.
+     * @param countInt          Number of required results.
+     * @param sortBy            SortBy.
+     * @param sortOrder         Sorting order.
+     * @param domainName        Domain name.
+     * @param attributes        Attributes in the request.
+     * @param excludeAttributes Exclude attributes.
+     * @return SCIM response.
      */
     default SCIMResponse listWithGET(UserManager userManager, String filter, Integer startIndexInt, Integer countInt,
-            String sortBy, String sortOrder, String domainName, String attributes, String excludeAttributes) {
+                String sortBy, String sortOrder, String domainName, String attributes, String excludeAttributes) {
+
+        return null;
+    }
+
+    /*
+     * Get resources with cursor.
+     *
+     * @param userManager       User manager.
+     * @param filter            Filter to be executed.
+     * @param cursor            Cursor value for pagination.
+     * @param countInt          Number of required results.
+     * @param sortBy            SortBy.
+     * @param sortOrder         Sorting order.
+     * @param domainName        Domain name.
+     * @param attributes        Attributes in the request.
+     * @param excludeAttributes Exclude attributes.
+     * @return SCIM response.
+     */
+    default SCIMResponse listWithGET(UserManager userManager, String filter, String cursor, Integer countInt,
+                  String sortBy, String sortOrder, String domainName, String attributes, String excludeAttributes) {
 
         return null;
     }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMConstants.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMConstants.java
@@ -69,6 +69,12 @@ public class SCIMConstants {
 
     public static final String DEFAULT = "default";
 
+    //Cursor Pagination types and other
+    public static final String OFFSET = "offset";
+    public static final String CURSOR = "cursor";
+    public static final String VALUE = "value";
+    public static final String DIRECTION = "direction";
+    public static final String NEXT = "NEXT";
 
     /**
      * Constants found in core-common schema.
@@ -130,6 +136,12 @@ public class SCIMConstants {
         public static final String RESOURCES = "Resources";
         public static final String ITEMS_PER_PAGE = "itemsPerPage";
         public static final String START_INDEX = "startIndex";
+        public static final String NEXT_CURSOR = "nextCursor";
+        public static final String PREVIOUS_CURSOR = "previousCursor";
+        public static final String PREVIOUS = "PREVIOUS";
+        public static final String NEXT = "NEXT";
+        public static final String DIRECTION = "direction";
+        public static final String VALUE = "value";
     }
 
     /**
@@ -620,6 +632,12 @@ public class SCIMConstants {
                 "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig:etag.supported";
         public static final String AUTHENTICATION_SCHEMAS_DOCUMENTATION_URI_URI =
                 "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig:authenticationSchemes.documentationUri";
+        public static final String PAGINATION = "pagination";
+        public static final String PAGINATION_URI =
+                "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig:pagination";
+        public static final String CURSOR = "cursor";
+        public static final String CURSOR_URI =
+                "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig:pagination.cursor";
 
 
         /*******Attributes descriptions of the attributes found in Service Provider Config Schema.***************/
@@ -627,6 +645,8 @@ public class SCIMConstants {
         public static final String DOCUMENTATION_URI_DESC = "An HTTP-addressable URL pointing to the service " +
                 "provider's human-consumable help documentation.";
         public static final String PATCH_DESC = "A complex type that specifies PATCH configuration options.";
+        public static final String PAGINATION_DESC = "A complex type which specifies the pagination types available.";
+        public static final String CURSOR_DESC = "A boolean which specifies if cursor pagination is supported";
         public static final String BULK_DESC = "A complex type that specifies bulk configuration options.";
         public static final String FILTERS_DESC = "A complex type that specifies FILTER options.";
         public static final String CHANGE_PASSWORD_DESC = "A complex type that specifies configuration options " +
@@ -755,6 +775,7 @@ public class SCIMConstants {
         public static final String EXCLUDED_ATTRIBUTES = "excludedAttributes";
         public static final String COUNT = "count";
         public static final String START_INDEX = "startIndex";
+        public static final String CURSOR = "cursor";
         public static final String SORT_BY = "sortBy";
         public static final String SORT_ORDER = "sortOrder";
         public static final String FILTER = "filter";

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMSchemaDefinitions.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMSchemaDefinitions.java
@@ -1216,6 +1216,15 @@ public class SCIMSchemaDefinitions {
                                 .EXTERNAL)),
                         null);
 
+        public static final SCIMAttributeSchema CURSOR_PAGINATION =
+                SCIMAttributeSchema.createSCIMAttributeSchema(
+                        SCIMConstants.ServiceProviderConfigSchemaConstants.CURSOR_URI,
+                        SCIMConstants.ServiceProviderConfigSchemaConstants.CURSOR,
+                        SCIMDefinitions.DataType.BOOLEAN, false,
+                        SCIMConstants.ServiceProviderConfigSchemaConstants.CURSOR_DESC, true, false,
+                        SCIMDefinitions.Mutability.READ_ONLY, SCIMDefinitions.Returned.DEFAULT,
+                        SCIMDefinitions.Uniqueness.NONE, null, null, null);
+
         public static final SCIMAttributeSchema TYPE =
                 SCIMAttributeSchema.createSCIMAttributeSchema(SCIMConstants.ServiceProviderConfigSchemaConstants
                                 .TYPE_URL,
@@ -1319,7 +1328,15 @@ public class SCIMSchemaDefinitions {
                         new ArrayList<AttributeSchema>(Arrays.asList(NAME, DESCRIPTION,
                                 SPEC_URI, AUTHENTICATION_SCHEMES_DOCUMENTATION_URI, TYPE, PRIMARY)));
 
-
+        public static final SCIMAttributeSchema PAGINATION =
+                SCIMAttributeSchema.createSCIMAttributeSchema(
+                        SCIMConstants.ServiceProviderConfigSchemaConstants.PAGINATION_URI,
+                        SCIMConstants.ServiceProviderConfigSchemaConstants.PAGINATION,
+                        SCIMDefinitions.DataType.COMPLEX, false,
+                        SCIMConstants.ServiceProviderConfigSchemaConstants.PAGINATION_DESC, true, false,
+                        SCIMDefinitions.Mutability.READ_ONLY, SCIMDefinitions.Returned.DEFAULT,
+                        SCIMDefinitions.Uniqueness.NONE, null, null,
+                        new ArrayList<AttributeSchema>(Arrays.asList(CURSOR_PAGINATION)));
     }
 
     /**
@@ -1490,6 +1507,7 @@ public class SCIMSchemaDefinitions {
                     SCIMServiceProviderConfigSchemaDefinition.SORT,
                     SCIMServiceProviderConfigSchemaDefinition.FILTER,
                     SCIMServiceProviderConfigSchemaDefinition.CHANGE_PASSWORD,
+                    SCIMServiceProviderConfigSchemaDefinition.PAGINATION,
                     SCIMServiceProviderConfigSchemaDefinition.ETAG,
                     SCIMServiceProviderConfigSchemaDefinition.AUTHENTICATION_SCHEMES);
 

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/codeutils/SearchRequest.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/codeutils/SearchRequest.java
@@ -16,7 +16,14 @@
 
 package org.wso2.charon3.core.utils.codeutils;
 
+import org.apache.commons.lang.StringUtils;
+import org.json.JSONObject;
+import org.wso2.charon3.core.objects.plainobjects.Cursor;
+import org.wso2.charon3.core.schema.SCIMConstants;
+
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 
 /**
  * this corresponds to the /.search request object
@@ -40,6 +47,7 @@ public class SearchRequest {
     private String sortBy;
     private String sortOder;
     private String domainName;
+    private Cursor cursor;
 
     public String getCountStr() {
         return countStr;
@@ -55,6 +63,28 @@ public class SearchRequest {
 
     public void setStartIndexStr(String startIndexStr) {
         this.startIndexStr = startIndexStr;
+    }
+
+    public Cursor getCursor() {
+        return cursor;
+    }
+
+    public void setCursor(String cursor) {
+
+        Cursor tempCursor = new Cursor(null, null);
+        //When using cursor pagination and the cursor is null, it means it is the first request so cursor = "".
+        if (StringUtils.isEmpty(cursor)) {
+            tempCursor.setCursorValue(StringUtils.EMPTY);
+            tempCursor.setDirection(SCIMConstants.NEXT);
+        } else {
+            Base64.Decoder decoder = Base64.getDecoder();
+            byte[] cursorBytes = decoder.decode(cursor.getBytes(StandardCharsets.UTF_8));
+            String cursorString = new String(cursorBytes, StandardCharsets.UTF_8);
+            JSONObject jsonCursor = new JSONObject(cursorString);
+            tempCursor.setCursorValue(jsonCursor.getString(SCIMConstants.VALUE));
+            tempCursor.setDirection(jsonCursor.getString(SCIMConstants.DIRECTION));
+        }
+        this.cursor = tempCursor;
     }
 
     public String getSchema() {

--- a/modules/charon-core/src/test/java/org/wso2/charon3/core/utils/ResourceManagerUtilTest.java
+++ b/modules/charon-core/src/test/java/org/wso2/charon3/core/utils/ResourceManagerUtilTest.java
@@ -23,6 +23,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.charon3.core.exceptions.BadRequestException;
 import org.wso2.charon3.core.exceptions.CharonException;
+import org.wso2.charon3.core.objects.plainobjects.Cursor;
 import org.wso2.charon3.core.schema.AttributeSchema;
 import org.wso2.charon3.core.schema.SCIMAttributeSchema;
 import org.wso2.charon3.core.schema.SCIMResourceTypeSchema;
@@ -263,6 +264,67 @@ public class ResourceManagerUtilTest {
 
         Integer index = ResourceManagerUtil.processStartIndex(startIndex);
         Assert.assertEquals(index, expectedIndex);
+    }
+
+    @DataProvider(name = "dataForProcessCursor")
+    public Object[][] dataToProcessCursor() {
+
+        return new Object[][]{
+
+                {"eyJ2YWx1ZSI6IkFjaGFsYV8xMzEiLCJkaXJlY3Rpb24iOiJQUkVWSU9VUyJ9", "Achala_131", "PREVIOUS"},
+                {"", "" , "NEXT"},
+                {null, "", "NEXT"}
+        };
+    }
+
+    @Test(dataProvider = "dataForProcessCursor")
+    public void testProcessCursor(String cursorStr, String expectedCursor, String expectedDirection) {
+
+        Cursor cursor = ResourceManagerUtil.processCursor(cursorStr);
+        Assert.assertEquals(cursor.getCursorValue(), expectedCursor);
+        Assert.assertEquals(cursor.getDirection(), expectedDirection);
+    }
+
+    @DataProvider(name = "dataForProcessPagination")
+    public Object[][] dataToProcessPagination() {
+
+        return new Object[][]{
+
+                {null, "eyJ2YWx1ZSI6IkFjaGFsYV8xMzEiLCJkaXJlY3Rpb24iOiJQUkVWSU9VUyJ9", "cursor"},
+                {null, "eyJ2YWx1ZSI6IkFjaGFsYV8xMzEiLCJkaXJlY3Rpb24iOiJQUkVWSU9VUyJ9", "cursor"},
+                {0, null, "offset"},
+                {null, null, "offset"},
+                {10, null, "offset"},
+                {-5, null, "offset"},
+        };
+    }
+
+    @Test(dataProvider = "dataForProcessPagination")
+    public void testProcessPagination(Integer startIndex, String cursorString, String expectedResult)
+            throws CharonException {
+
+        String paginationType = ResourceManagerUtil.processPagination(startIndex, cursorString);
+        Assert.assertEquals(paginationType, expectedResult);
+    }
+
+    @DataProvider(name = "dataForProcessPaginationException")
+    public Object[][] dataToProcessPaginationException() {
+
+        return new Object[][]{
+
+                {0, "eyJ2YWx1ZSI6IkFjaGFsYV8xMzEiLCJkaXJlY3Rpb24iOiJQUkVWSU9VUyJ9"},
+                {10, "eyJ2YWx1ZSI6IkFjaGFsYV8xMzEiLCJkaXJlY3Rpb24iOiJQUkVWSU9VUyJ9"},
+                {-3, "eyJ2YWx1ZSI6IkFjaGFsYV8xMzEiLCJkaXJlY3Rpb24iOiJQUkVWSU9VUyJ9"},
+        };
+    }
+
+    @Test(dataProvider = "dataForProcessPaginationException", expectedExceptions = CharonException.class)
+    public void testProcessPaginationException(Integer startIndex, String cursorString)
+            throws CharonException {
+
+        ResourceManagerUtil.processPagination(startIndex, cursorString);
+        // This method is for testing of throwing CharonException when both cursor and offset are given,
+        // hence no assertion.
     }
 
     @DataProvider(name = "dataForProcessStartIndexString")

--- a/modules/charon-utils/src/main/java/org/wso2/charon3/utils/usermanager/InMemoryUserManager.java
+++ b/modules/charon-utils/src/main/java/org/wso2/charon3/utils/usermanager/InMemoryUserManager.java
@@ -83,9 +83,10 @@ public class InMemoryUserManager implements UserManager {
     }
 
     @Override
-    public UsersGetResponse listUsersWithGET(Node rootNode, int startIndex, int count, String sortBy,
-                                         String sortOrder, String domainName, Map<String, Boolean> requiredAttributes)
+    public UsersGetResponse listUsersWithGET(Node rootNode, int startIndex, int count, String sortBy, String sortOrder,
+                                             String domainName, Map<String, Boolean> requiredAttributes)
             throws CharonException, NotImplementedException, BadRequestException {
+
         if (sortBy != null || sortOrder != null) {
             throw new NotImplementedException("Sorting is not supported");
         }  else if (startIndex != 1) {


### PR DESCRIPTION
## Purpose
The purpose of this PR is to get the initial phase of cursor pagination for SCIM resource listings working with the Identity Server in JDBC and LDAP user stores.

## Goals
- User passes in the cursor or startIndex and the limit and the IS provides a (cursor or offset) paginated result.
- Ability to travel forwards and backwards across pages using cursor pagination.
- Cursor paginated functionality for both JDBC and LDAP user stores.

## Related Issues
- https://github.com/wso2/product-is/issues/13294

## Related PRs
- https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/417
- https://github.com/wso2/carbon-kernel/pull/3281

## Test environment
1. Java versions
- JDK 1.8
- Open JDK 11.0.15
2. OS
- Ubuntu 20.04
3. IS:
- WSO2IS-5.12.0-alpha14, 
4. User stores:
- JDBC
  - DB2 - 11.5.7.0
  - Oracle - 19.3.0-ee
  - MSSQL - Microsoft SQL Server 2019 - 15.0.4223.1 (X64) 
  - MySQL - Ver 8.0.29
  - Postgres - PostgreSQL 14.3 
- LDAP