### PR TITLE
Changing ServiceProviderConfig to show cursor pagination is enabled.

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/config/CharonConfiguration.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/config/CharonConfiguration.java
@@ -39,6 +39,7 @@ public class CharonConfiguration implements Configuration {
 
     //default count value for pagination
     private int count;
+    private boolean cursorSupport;
 
     /*
      * set documentationURL
@@ -76,6 +77,15 @@ public class CharonConfiguration implements Configuration {
     public void setFilterSupport(boolean supported, int maxResults) {
         this.filterSupport = supported;
         this.maxResults = maxResults;
+    }
+
+    /*
+     * Set pagination support
+     * @param supportedCursor
+     */
+    public void setPaginationSupport(boolean supported) {
+
+        this.cursorSupport = supported;
     }
 
     /*
@@ -145,6 +155,7 @@ public class CharonConfiguration implements Configuration {
         configMap.put(SCIMConfigConstants.PATCH, patchSupport);
         configMap.put(SCIMConfigConstants.AUTHENTICATION_SCHEMES, authenticationSchemes);
         configMap.put(SCIMConfigConstants.PAGINATION_DEFAULT_COUNT, count);
+        configMap.put(SCIMConfigConstants.CURSOR, cursorSupport);
         return  configMap;
     }
 

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/config/CharonConfiguration.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/config/CharonConfiguration.java
@@ -79,11 +79,11 @@ public class CharonConfiguration implements Configuration {
         this.maxResults = maxResults;
     }
 
-    /*
+    /**
      * Set pagination support
-     * @param supportedCursor
+     * @param supported
      */
-    public void setPaginationSupport(boolean supported) {
+    public void setCursorPaginationSupport(boolean supported) {
 
         this.cursorSupport = supported;
     }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/config/SCIMConfigConstants.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/config/SCIMConfigConstants.java
@@ -47,7 +47,7 @@ public class SCIMConfigConstants {
     public static final String AUTHENTICATION_SCHEMES = "authenticationSchemes";
     public static final String SCIM_SCHEMA_EXTENSION_CONFIG = "scim2-schema-extension.config";
     public static final String PAGINATION_DEFAULT_COUNT = "pagination-default-count";
-
+    public static final String CURSOR = "cursor";
 
 }
 

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONEncoder.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONEncoder.java
@@ -418,6 +418,10 @@ public class JSONEncoder {
         changePasswordObject.put(SCIMConstants.ServiceProviderConfigSchemaConstants.SUPPORTED,
                 config.get(SCIMConfigConstants.CHNAGE_PASSWORD));
 
+        JSONObject paginationObject = new JSONObject();
+        paginationObject.put(SCIMConstants.ServiceProviderConfigSchemaConstants.CURSOR,
+                config.get(SCIMConfigConstants.CURSOR));
+
         JSONArray authenticationSchemesArray = new JSONArray();
         ArrayList<Object[]> values = (ArrayList<Object[]>) config.get(SCIMConfigConstants.AUTHENTICATION_SCHEMES);
 
@@ -457,6 +461,8 @@ public class JSONEncoder {
                 etagObject);
         rootObject.put(SCIMConstants.ServiceProviderConfigSchemaConstants.AUTHENTICATION_SCHEMAS,
                 authenticationSchemesArray);
+        rootObject.put(SCIMConstants.ServiceProviderConfigSchemaConstants.PAGINATION,
+                paginationObject);
 
         return rootObject.toString();
 

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMConstants.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMConstants.java
@@ -620,6 +620,12 @@ public class SCIMConstants {
                 "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig:etag.supported";
         public static final String AUTHENTICATION_SCHEMAS_DOCUMENTATION_URI_URI =
                 "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig:authenticationSchemes.documentationUri";
+        public static final String PAGINATION = "pagination";
+        public static final String PAGINATION_URI =
+                "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig:pagination";
+        public static final String CURSOR = "cursor";
+        public static final String CURSOR_URI =
+                "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig:pagination.cursor";
 
 
         /*******Attributes descriptions of the attributes found in Service Provider Config Schema.***************/
@@ -627,6 +633,8 @@ public class SCIMConstants {
         public static final String DOCUMENTATION_URI_DESC = "An HTTP-addressable URL pointing to the service " +
                 "provider's human-consumable help documentation.";
         public static final String PATCH_DESC = "A complex type that specifies PATCH configuration options.";
+        public static final String PAGINATION_DESC = "A complex type which specifies the pagination types available.";
+        public static final String CURSOR_DESC = "A boolean which specifies if cursor pagination is supported";
         public static final String BULK_DESC = "A complex type that specifies bulk configuration options.";
         public static final String FILTERS_DESC = "A complex type that specifies FILTER options.";
         public static final String CHANGE_PASSWORD_DESC = "A complex type that specifies configuration options " +

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMSchemaDefinitions.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMSchemaDefinitions.java
@@ -1216,6 +1216,15 @@ public class SCIMSchemaDefinitions {
                                 .EXTERNAL)),
                         null);
 
+        public static final SCIMAttributeSchema CURSOR_PAGINATION =
+                SCIMAttributeSchema.createSCIMAttributeSchema(
+                        SCIMConstants.ServiceProviderConfigSchemaConstants.CURSOR_URI,
+                        SCIMConstants.ServiceProviderConfigSchemaConstants.CURSOR,
+                        SCIMDefinitions.DataType.BOOLEAN, false,
+                        SCIMConstants.ServiceProviderConfigSchemaConstants.CURSOR_DESC, true, false,
+                        SCIMDefinitions.Mutability.READ_ONLY, SCIMDefinitions.Returned.DEFAULT,
+                        SCIMDefinitions.Uniqueness.NONE, null, null, null);
+
         public static final SCIMAttributeSchema TYPE =
                 SCIMAttributeSchema.createSCIMAttributeSchema(SCIMConstants.ServiceProviderConfigSchemaConstants
                                 .TYPE_URL,
@@ -1319,7 +1328,15 @@ public class SCIMSchemaDefinitions {
                         new ArrayList<AttributeSchema>(Arrays.asList(NAME, DESCRIPTION,
                                 SPEC_URI, AUTHENTICATION_SCHEMES_DOCUMENTATION_URI, TYPE, PRIMARY)));
 
-
+        public static final SCIMAttributeSchema PAGINATION =
+                SCIMAttributeSchema.createSCIMAttributeSchema(
+                        SCIMConstants.ServiceProviderConfigSchemaConstants.PAGINATION_URI,
+                        SCIMConstants.ServiceProviderConfigSchemaConstants.PAGINATION,
+                        SCIMDefinitions.DataType.COMPLEX, false,
+                        SCIMConstants.ServiceProviderConfigSchemaConstants.PAGINATION_DESC, true, false,
+                        SCIMDefinitions.Mutability.READ_ONLY, SCIMDefinitions.Returned.DEFAULT,
+                        SCIMDefinitions.Uniqueness.NONE, null, null,
+                        new ArrayList<AttributeSchema>(Arrays.asList(CURSOR_PAGINATION)));
     }
 
     /**
@@ -1490,6 +1507,7 @@ public class SCIMSchemaDefinitions {
                     SCIMServiceProviderConfigSchemaDefinition.SORT,
                     SCIMServiceProviderConfigSchemaDefinition.FILTER,
                     SCIMServiceProviderConfigSchemaDefinition.CHANGE_PASSWORD,
+                    SCIMServiceProviderConfigSchemaDefinition.PAGINATION,
                     SCIMServiceProviderConfigSchemaDefinition.ETAG,
                     SCIMServiceProviderConfigSchemaDefinition.AUTHENTICATION_SCHEMES);
 


### PR DESCRIPTION
## Purpose
As per the [cursor based pagination draft by Matt Peterson](https://datatracker.ietf.org/doc/html/draft-peterson-scim-cursor-pagination-00#section-2), A SCIM Service provider implementing cursor-based pagination SHOULD include the following additional attribute in the JSON document returned by the/ServiceProviderConfig endpoint:

{
        "schemas": [
        "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"],
        ...
        "pagination": {
        "cursor":true
        },
        .....
}

A part in completion of: https://github.com/wso2/product-is/issues/13294

## Goals
When the ServiceProviderConfig endpoint is called, it will inform the user that cursor pagination is supported.

## Related PRs
https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/425

## Test environment
JDK 1.8, Ubuntu 20.04, WSO2IS-5.12.0-alpha14, Chrome. 