### PR TITLE
Changing the response type of GET and POST/.Search

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/extensions/UserManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/extensions/UserManager.java
@@ -24,6 +24,7 @@ import org.wso2.charon3.core.exceptions.NotFoundException;
 import org.wso2.charon3.core.exceptions.NotImplementedException;
 import org.wso2.charon3.core.objects.Group;
 import org.wso2.charon3.core.objects.User;
+import org.wso2.charon3.core.objects.plainobjects.UsersGetResponse;
 import org.wso2.charon3.core.schema.AttributeSchema;
 import org.wso2.charon3.core.utils.codeutils.Node;
 import org.wso2.charon3.core.utils.codeutils.PatchOperation;
@@ -65,8 +66,8 @@ public interface UserManager {
      * @throws NotImplementedException Operation note implemented
      * @throws BadRequestException     Bad request
      */
-    default List<Object> listUsersWithGET(Node node, Integer startIndex, Integer count, String sortBy, String sortOrder,
-            String domainName, Map<String, Boolean> requiredAttributes)
+    default UsersGetResponse listUsersWithGET(Node node, Integer startIndex, Integer count, String sortBy,
+                        String sortOrder, String domainName, Map<String, Boolean> requiredAttributes)
             throws CharonException, NotImplementedException, BadRequestException {
 
         return null;
@@ -83,7 +84,7 @@ public interface UserManager {
      * String, Map) } method.
      */
     @Deprecated
-    default List<Object> listUsersWithGET(Node node, int startIndex, int count, String sortBy, String sortOrder,
+    default UsersGetResponse listUsersWithGET(Node node, int startIndex, int count, String sortBy, String sortOrder,
             String domainName, Map<String, Boolean> requiredAttributes)
             throws CharonException, NotImplementedException, BadRequestException {
 
@@ -91,14 +92,14 @@ public interface UserManager {
     }
 
     @Deprecated
-    default List<Object> listUsersWithGET(Node node, int startIndex, int count, String sortBy, String sortOrder,
+    default UsersGetResponse listUsersWithGET(Node node, int startIndex, int count, String sortBy, String sortOrder,
                                          Map<String, Boolean> requiredAttributes)
             throws CharonException, NotImplementedException, BadRequestException {
 
         return listUsersWithGET(node, startIndex, count, sortBy, sortOrder, null, requiredAttributes);
     }
 
-    public List<Object> listUsersWithPost(SearchRequest searchRequest, Map<String, Boolean> requiredAttributes)
+    public UsersGetResponse listUsersWithPost(SearchRequest searchRequest, Map<String, Boolean> requiredAttributes)
             throws CharonException, NotImplementedException, BadRequestException;
 
     public User updateUser(User updatedUser, Map<String, Boolean> requiredAttributes)

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/plainobjects/UsersGetResponse.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/plainobjects/UsersGetResponse.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.charon3.core.objects.plainobjects;
+
+import org.wso2.charon3.core.objects.User;
+import java.util.List;
+
+
+public class UsersGetResponse {
+
+    private int totalUsers;
+    private List<User> users;
+
+    /**
+     * Constructor used to build a response object when not using cursor pagination.
+     */
+    public UsersGetResponse(int totalUsers, List<User> users) {
+
+        this.totalUsers = totalUsers;
+        this.users = users;
+    }
+
+    public int getTotalUsers() {
+
+        return totalUsers;
+    }
+
+    public void setTotalUsers(int totalUsers) {
+
+        this.totalUsers = totalUsers;
+    }
+
+    public List<User> getUsers() {
+        return users;
+    }
+
+    public void setUsers(List<User> filteredUsers) {
+        this.users = filteredUsers;
+    }
+}

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/plainobjects/UsersGetResponse.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/plainobjects/UsersGetResponse.java
@@ -21,7 +21,10 @@ package org.wso2.charon3.core.objects.plainobjects;
 import org.wso2.charon3.core.objects.User;
 import java.util.List;
 
-
+/**
+ * This class representation can be used to create a UsersGetResponse type object which carries the total number of
+ * users identified from the filter and the list of users returned for this request.
+ */
 public class UsersGetResponse {
 
     private int totalUsers;
@@ -47,10 +50,12 @@ public class UsersGetResponse {
     }
 
     public List<User> getUsers() {
+
         return users;
     }
 
     public void setUsers(List<User> filteredUsers) {
+
         this.users = filteredUsers;
     }
 }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/UserResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/UserResourceManager.java
@@ -439,6 +439,9 @@ public class UserResourceManager extends AbstractResourceManager {
             SCIMResourceTypeSchema schema, String attributes, String excludeAttributes, int startIndex)
             throws NotFoundException, CharonException, BadRequestException {
 
+        if (usersGetResponse == null) {
+            usersGetResponse = new UsersGetResponse(0, Collections.emptyList());
+        }
         if (usersGetResponse.getUsers() == null) {
             usersGetResponse.setUsers(Collections.emptyList());
         }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/UserResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/UserResourceManager.java
@@ -424,7 +424,7 @@ public class UserResourceManager extends AbstractResourceManager {
     /**
      * Method to process a user list and return a SCIM response.
      *
-     * @param usersGetResponse  Filtered user list and limit.
+     * @param usersGetResponse  Filtered user list and total user count.
      * @param encoder           Json encoder
      * @param schema            Schema
      * @param attributes        Required attributes

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/UserResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/UserResourceManager.java
@@ -33,6 +33,7 @@ import org.wso2.charon3.core.exceptions.NotImplementedException;
 import org.wso2.charon3.core.extensions.UserManager;
 import org.wso2.charon3.core.objects.ListedResource;
 import org.wso2.charon3.core.objects.User;
+import org.wso2.charon3.core.objects.plainobjects.UsersGetResponse;
 import org.wso2.charon3.core.protocol.ResponseCodeConstants;
 import org.wso2.charon3.core.protocol.SCIMResponse;
 import org.wso2.charon3.core.schema.SCIMConstants;
@@ -292,11 +293,11 @@ public class UserResourceManager extends AbstractResourceManager {
 
             // API user should pass a user manager to UserResourceEndpoint.
             if (userManager != null) {
-                List<Object> tempList = userManager
+                UsersGetResponse usersGetResponse = userManager
                         .listUsersWithGET(rootNode, startIndex, count, sortBy, sortOrder, domainName,
                                 requiredAttributes);
 
-                return processUserList(tempList, encoder, schema, attributes, excludeAttributes, startIndex);
+                return processUserList(usersGetResponse, encoder, schema, attributes, excludeAttributes, startIndex);
             } else {
                 String error = "Provided user manager handler is null.";
                 // Log the error as well.
@@ -357,10 +358,10 @@ public class UserResourceManager extends AbstractResourceManager {
 
             // API user should pass a user manager to UserResourceEndpoint.
             if (userManager != null) {
-                List<Object> tempList = userManager
+                UsersGetResponse usersGetResponse = userManager
                         .listUsersWithGET(rootNode, startIndex, count, sortBy, sortOrder, domainName,
                                 requiredAttributes);
-                return processUserList(tempList, encoder, schema, attributes, excludeAttributes, startIndex);
+                return processUserList(usersGetResponse, encoder, schema, attributes, excludeAttributes, startIndex);
             } else {
                 String error = "Provided user manager handler is null.";
                 // Log the error as well.
@@ -423,7 +424,7 @@ public class UserResourceManager extends AbstractResourceManager {
     /**
      * Method to process a user list and return a SCIM response.
      *
-     * @param tempList          Filtered user list
+     * @param usersGetResponse  Filtered user list and limit.
      * @param encoder           Json encoder
      * @param schema            Schema
      * @param attributes        Required attributes
@@ -434,35 +435,19 @@ public class UserResourceManager extends AbstractResourceManager {
      * @throws CharonException
      * @throws BadRequestException
      */
-    private SCIMResponse processUserList(List<Object> tempList, JSONEncoder encoder, SCIMResourceTypeSchema schema,
+    private SCIMResponse processUserList(UsersGetResponse usersGetResponse, JSONEncoder encoder, SCIMResourceTypeSchema schema,
             String attributes, String excludeAttributes, int startIndex)
             throws NotFoundException, CharonException, BadRequestException {
 
-        int totalResults = 0;
-        List<Object> returnedUsers;
-        if (tempList == null) {
-            tempList = Collections.emptyList();
+        if (usersGetResponse.getUsers() == null) {
+            usersGetResponse.setUsers(Collections.emptyList());
         }
-        try {
-            totalResults = (int) tempList.get(0);
-            tempList.remove(0);
-        } catch (IndexOutOfBoundsException e) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("Group result list is empty.");
-            }
-            totalResults = tempList.size();
-        } catch (ClassCastException ex) {
-            logger.debug("Parse error while getting the user result count. Setting result count as: " + tempList.size(),
-                    ex);
-            totalResults = tempList.size();
-        }
-        returnedUsers = tempList;
-        for (Object user : returnedUsers) {
+        for (User user : usersGetResponse.getUsers()) {
             // Perform service provider side validation.
-            ServerSideValidator.validateRetrievedSCIMObjectInList((User) user, schema, attributes, excludeAttributes);
+            ServerSideValidator.validateRetrievedSCIMObjectInList(user, schema, attributes, excludeAttributes);
         }
         // Create a listed resource object out of the returned users list.
-        ListedResource listedResource = createListedResource(returnedUsers, startIndex, totalResults);
+        ListedResource listedResource = createListedResource(usersGetResponse, startIndex);
         // Convert the listed resource into specific format.
         String encodedListedResource = encoder.encodeSCIMObject(listedResource);
         // If there are any http headers to be added in the response header.
@@ -516,25 +501,17 @@ public class UserResourceManager extends AbstractResourceManager {
                             CopyUtil.deepCopy(schema), searchRequest.getAttributesAsString(),
                     searchRequest.getExcludedAttributesAsString());
 
-            List<Object> returnedUsers;
-            int totalResults = 0;
             //API user should pass a usermanager usermanager to UserResourceEndpoint.
             if (userManager != null) {
-                List<Object> tempList = userManager.listUsersWithPost(searchRequest, requiredAttributes);
-
-                totalResults = (int) tempList.get(0);
-                tempList.remove(0);
-
-                returnedUsers = tempList;
-
-                for (Object user : returnedUsers) {
+                UsersGetResponse usersGetResponse = userManager.listUsersWithPost(searchRequest, requiredAttributes);
+                for (User user : usersGetResponse.getUsers()) {
                     //perform service provider side validation.
-                    ServerSideValidator.validateRetrievedSCIMObjectInList((User) user, schema,
+                    ServerSideValidator.validateRetrievedSCIMObjectInList(user, schema,
                             searchRequest.getAttributesAsString(), searchRequest.getExcludedAttributesAsString());
                 }
                 //create a listed resource object out of the returned users list.
                 ListedResource listedResource = createListedResource(
-                        returnedUsers, searchRequest.getStartIndex(), totalResults);
+                        usersGetResponse, searchRequest.getStartIndex());
                 //convert the listed resource into specific format.
                 String encodedListedResource = encoder.encodeSCIMObject(listedResource);
                 //if there are any http headers to be added in the response header.
@@ -773,22 +750,21 @@ public class UserResourceManager extends AbstractResourceManager {
     /*
      * Creates the Listed Resource.
      *
-     * @param users
+     * @param usersGetResponse
      * @param startIndex
-     * @param totalResults
      * @return
      * @throws CharonException
      * @throws NotFoundException
      */
-    protected ListedResource createListedResource(List<Object> users, int startIndex, int totalResults)
+    protected ListedResource createListedResource(UsersGetResponse usersGetResponse, int startIndex)
             throws CharonException, NotFoundException {
         ListedResource listedResource = new ListedResource();
         listedResource.setSchema(SCIMConstants.LISTED_RESOURCE_CORE_SCHEMA_URI);
-        listedResource.setTotalResults(totalResults);
+        listedResource.setTotalResults(usersGetResponse.getTotalUsers());
         listedResource.setStartIndex(startIndex);
-        listedResource.setItemsPerPage(users.size());
-        for (Object user : users) {
-            Map<String, Attribute> userAttributes = ((User) user).getAttributeList();
+        listedResource.setItemsPerPage(usersGetResponse.getUsers().size());
+        for (User user : usersGetResponse.getUsers()) {
+            Map<String, Attribute> userAttributes = user.getAttributeList();
             listedResource.setResources(userAttributes);
         }
         return listedResource;

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/UserResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/UserResourceManager.java
@@ -435,8 +435,8 @@ public class UserResourceManager extends AbstractResourceManager {
      * @throws CharonException
      * @throws BadRequestException
      */
-    private SCIMResponse processUserList(UsersGetResponse usersGetResponse, JSONEncoder encoder, SCIMResourceTypeSchema schema,
-            String attributes, String excludeAttributes, int startIndex)
+    private SCIMResponse processUserList(UsersGetResponse usersGetResponse, JSONEncoder encoder,
+            SCIMResourceTypeSchema schema, String attributes, String excludeAttributes, int startIndex)
             throws NotFoundException, CharonException, BadRequestException {
 
         if (usersGetResponse.getUsers() == null) {

--- a/modules/charon-core/src/test/java/org/wso2/charon3/core/protocol/endpoints/UserResourceManagerTest.java
+++ b/modules/charon-core/src/test/java/org/wso2/charon3/core/protocol/endpoints/UserResourceManagerTest.java
@@ -991,8 +991,7 @@ public class UserResourceManagerTest {
     @DataProvider(name = "dataForListWithPOST")
     public Object[][] dataToListWithPOST() throws BadRequestException, CharonException, InternalErrorException {
 
-        List<Object> tempList = new ArrayList<>();
-        tempList.add(1);
+        List<User> tempList = new ArrayList<>();
         tempList.add(getNewUser());
         return new Object[][]{
                 {RESOURCE_STRING, tempList}
@@ -1005,8 +1004,8 @@ public class UserResourceManagerTest {
 
         abstractResourceManager.when(() -> AbstractResourceManager.getResourceEndpointURL(SCIMConstants.USER_ENDPOINT))
                 .thenReturn(SCIM2_USER_ENDPOINT + "/.search");
-        Mockito.when(userManager.listUsersWithPost(any(SearchRequest.class), anyMap())).
-                thenReturn(new UsersGetResponse(0, tempList));
+        Mockito.when(userManager.listUsersWithPost(any(SearchRequest.class), anyMap()))
+                .thenReturn(new UsersGetResponse(1, tempList));
         SCIMResponse scimResponse = userResourceManager.listWithPOST(resourceString, userManager);
         Assert.assertEquals(scimResponse.getResponseStatus(), ResponseCodeConstants.CODE_OK);
     }

--- a/modules/charon-core/src/test/java/org/wso2/charon3/core/protocol/endpoints/UserResourceManagerTest.java
+++ b/modules/charon-core/src/test/java/org/wso2/charon3/core/protocol/endpoints/UserResourceManagerTest.java
@@ -38,6 +38,7 @@ import org.wso2.charon3.core.exceptions.NotFoundException;
 import org.wso2.charon3.core.exceptions.NotImplementedException;
 import org.wso2.charon3.core.extensions.UserManager;
 import org.wso2.charon3.core.objects.User;
+import org.wso2.charon3.core.objects.plainobjects.UsersGetResponse;
 import org.wso2.charon3.core.protocol.ResponseCodeConstants;
 import org.wso2.charon3.core.protocol.SCIMResponse;
 import org.wso2.charon3.core.schema.SCIMConstants;
@@ -999,12 +1000,13 @@ public class UserResourceManagerTest {
     }
 
     @Test(dataProvider = "dataForListWithPOST")
-    public void testListWithPOST(String resourceString, List<Object> tempList)
+    public void testListWithPOST(String resourceString, List<User> tempList)
             throws NotImplementedException, BadRequestException, CharonException {
 
         abstractResourceManager.when(() -> AbstractResourceManager.getResourceEndpointURL(SCIMConstants.USER_ENDPOINT))
                 .thenReturn(SCIM2_USER_ENDPOINT + "/.search");
-        Mockito.when(userManager.listUsersWithPost(any(SearchRequest.class), anyMap())).thenReturn(tempList);
+        Mockito.when(userManager.listUsersWithPost(any(SearchRequest.class), anyMap())).
+                thenReturn(new UsersGetResponse(0, tempList));
         SCIMResponse scimResponse = userResourceManager.listWithPOST(resourceString, userManager);
         Assert.assertEquals(scimResponse.getResponseStatus(), ResponseCodeConstants.CODE_OK);
     }

--- a/modules/charon-utils/src/main/java/org/wso2/charon3/utils/usermanager/InMemoryUserManager.java
+++ b/modules/charon-utils/src/main/java/org/wso2/charon3/utils/usermanager/InMemoryUserManager.java
@@ -102,7 +102,7 @@ public class InMemoryUserManager implements UserManager {
         for (Map.Entry<String, User> entry : inMemoryUserList.entrySet()) {
             userList.add(entry.getValue());
         }
-        return (UsersGetResponse) CopyUtil.deepCopy(new UsersGetResponse(userList.size(), userList));
+        return new UsersGetResponse(userList.size(), userList);
     }
 
     @Override

--- a/modules/charon-utils/src/main/java/org/wso2/charon3/utils/usermanager/InMemoryUserManager.java
+++ b/modules/charon-utils/src/main/java/org/wso2/charon3/utils/usermanager/InMemoryUserManager.java
@@ -30,6 +30,7 @@ import org.wso2.charon3.core.exceptions.NotImplementedException;
 import org.wso2.charon3.core.extensions.UserManager;
 import org.wso2.charon3.core.objects.Group;
 import org.wso2.charon3.core.objects.User;
+import org.wso2.charon3.core.objects.plainobjects.UsersGetResponse;
 import org.wso2.charon3.core.utils.CopyUtil;
 import org.wso2.charon3.core.utils.codeutils.Node;
 import org.wso2.charon3.core.utils.codeutils.SearchRequest;
@@ -81,8 +82,8 @@ public class InMemoryUserManager implements UserManager {
     }
 
     @Override
-    public List<Object> listUsersWithGET(Node rootNode, int startIndex, int count, String sortBy,
-                                         String sortOrder, String domainName, Map<String, Boolean> requiredAttributes)
+    public UsersGetResponse listUsersWithGET(Node rootNode, int startIndex, int count, String sortBy,
+                                             String sortOrder, String domainName, Map<String, Boolean> requiredAttributes)
             throws CharonException, NotImplementedException, BadRequestException {
         if (sortBy != null || sortOrder != null) {
             throw new NotImplementedException("Sorting is not supported");
@@ -95,25 +96,17 @@ public class InMemoryUserManager implements UserManager {
         }
     }
 
-    private List<Object> listUsers(Map<String, Boolean> requiredAttributes) {
-        List<Object> userList = new ArrayList<>();
-        userList.add(0);
-        //first item should contain the number of total results
+    private UsersGetResponse listUsers(Map<String, Boolean> requiredAttributes) throws CharonException {
+
+        List<User> userList = new ArrayList<>();
         for (Map.Entry<String, User> entry : inMemoryUserList.entrySet()) {
             userList.add(entry.getValue());
         }
-        userList.set(0, userList.size() - 1);
-        try {
-            return (List<Object>) CopyUtil.deepCopy(userList);
-        } catch (CharonException e) {
-            logger.error("Error in listing users");
-            return  null;
-        }
-
+        return (UsersGetResponse) CopyUtil.deepCopy(new UsersGetResponse(userList.size(), userList));
     }
 
     @Override
-    public List<Object> listUsersWithPost(SearchRequest searchRequest, Map<String, Boolean> requiredAttributes)
+    public UsersGetResponse listUsersWithPost(SearchRequest searchRequest, Map<String, Boolean> requiredAttributes)
             throws CharonException, NotImplementedException, BadRequestException {
 
         return listUsersWithGET(searchRequest.getFilter(), searchRequest.getStartIndex(), searchRequest.getCount(),

--- a/modules/charon-utils/src/main/java/org/wso2/charon3/utils/usermanager/InMemoryUserManager.java
+++ b/modules/charon-utils/src/main/java/org/wso2/charon3/utils/usermanager/InMemoryUserManager.java
@@ -83,7 +83,7 @@ public class InMemoryUserManager implements UserManager {
 
     @Override
     public UsersGetResponse listUsersWithGET(Node rootNode, int startIndex, int count, String sortBy,
-                                             String sortOrder, String domainName, Map<String, Boolean> requiredAttributes)
+                                         String sortOrder, String domainName, Map<String, Boolean> requiredAttributes)
             throws CharonException, NotImplementedException, BadRequestException {
         if (sortBy != null || sortOrder != null) {
             throw new NotImplementedException("Sorting is not supported");


### PR DESCRIPTION
## Purpose
In my attempts to implement cursor based pagination, it was noticed that the current method of returning the total number of results along with the list of users for GET requests and POST/.Search requests was to allocate the 1st position of a _List_ to carry the total results and the remainder to carry the users. It is not appropriate to store different data types in a _List_ therefore it was decided to refactor the code to change the return type to a custom java object which comprises of the users and total results. With the intention of supporting forwards cursor and backwards cursor for cursor pagination (Implemented [here](https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/417/commits/59a04cbd536928b7d620134ba12322d0f62d40ad) and [here](https://github.com/wso2/charon/pull/368/commits/7389fa01853122f80cdd8a3b1e8810bd0e20bd07#diff-32914d3be281f9ccb36fe8cc05d50a694f7364dbf5b6ba7623f7d29103998f38)).

## Goals
The same functionality is maintained while changing the return type from a _List_ to a _custom java object_.

## Related PRs
https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/426

## Test environment
Ubuntu 20.04, WSO2IS-5.12.0-beta2-SNAPSHOT