### PR TITLE
Changing the response type for listGroupsWithGET and listRolesWithGet

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/extensions/RoleManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/extensions/RoleManager.java
@@ -24,10 +24,10 @@ import org.wso2.charon3.core.exceptions.ConflictException;
 import org.wso2.charon3.core.exceptions.NotFoundException;
 import org.wso2.charon3.core.exceptions.NotImplementedException;
 import org.wso2.charon3.core.objects.Role;
+import org.wso2.charon3.core.objects.plainobjects.RolesGetResponse;
 import org.wso2.charon3.core.utils.codeutils.Node;
 import org.wso2.charon3.core.utils.codeutils.SearchRequest;
 
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -85,7 +85,7 @@ public interface RoleManager {
      * @throws NotImplementedException NotImplementedException.
      * @throws BadRequestException     BadRequestException.
      */
-    List<Object> listRolesWithGET(Node node, Integer startIndex, Integer count, String sortBy, String sortOrder)
+    RolesGetResponse listRolesWithGET(Node node, Integer startIndex, Integer count, String sortBy, String sortOrder)
             throws CharonException, NotImplementedException, BadRequestException;
 
     /**
@@ -112,6 +112,6 @@ public interface RoleManager {
      * @throws BadRequestException     BadRequestException.
      * @throws CharonException         CharonException.
      */
-    List<Object> listRolesWithPost(SearchRequest searchRequest)
+    RolesGetResponse listRolesWithPost(SearchRequest searchRequest)
             throws NotImplementedException, BadRequestException, CharonException;
 }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/extensions/UserManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/extensions/UserManager.java
@@ -24,6 +24,7 @@ import org.wso2.charon3.core.exceptions.NotFoundException;
 import org.wso2.charon3.core.exceptions.NotImplementedException;
 import org.wso2.charon3.core.objects.Group;
 import org.wso2.charon3.core.objects.User;
+import org.wso2.charon3.core.objects.plainobjects.GroupsGetResponse;
 import org.wso2.charon3.core.schema.AttributeSchema;
 import org.wso2.charon3.core.utils.codeutils.Node;
 import org.wso2.charon3.core.utils.codeutils.PatchOperation;
@@ -148,8 +149,8 @@ public interface UserManager {
     public void deleteGroup(String id)
             throws NotFoundException, CharonException, NotImplementedException, BadRequestException;
 
-    default List<Object> listGroupsWithGET(Node node, Integer startIndex, Integer count, String sortBy,
-            String sortOrder, String domainName, Map<String, Boolean> requiredAttributes)
+    default GroupsGetResponse listGroupsWithGET(Node node, Integer startIndex, Integer count, String sortBy,
+                               String sortOrder, String domainName, Map<String, Boolean> requiredAttributes)
             throws CharonException, NotImplementedException, BadRequestException {
         return null;
     }
@@ -164,14 +165,14 @@ public interface UserManager {
      * String, Map)} method.
      */
     @Deprecated
-    default List<Object> listGroupsWithGET(Node node, int startIndex, int count, String sortBy, String sortOrder,
+    default GroupsGetResponse listGroupsWithGET(Node node, int startIndex, int count, String sortBy, String sortOrder,
             String domainName, Map<String, Boolean> requiredAttributes)
             throws CharonException, NotImplementedException, BadRequestException {
         return null;
     }
 
     @Deprecated
-    default List<Object> listGroupsWithGET(Node node, int startIndex, int count, String sortBy,
+    default GroupsGetResponse listGroupsWithGET(Node node, int startIndex, int count, String sortBy,
                                           String sortOrder, Map<String, Boolean> requiredAttributes)
             throws CharonException, NotImplementedException, BadRequestException {
         return listGroupsWithGET(node, startIndex, count, sortBy, sortOrder, null, requiredAttributes);
@@ -218,7 +219,7 @@ public interface UserManager {
         throw new NotImplementedException();
     }
 
-    public List<Object> listGroupsWithPost(SearchRequest searchRequest, Map<String, Boolean> requiredAttributes)
+    public GroupsGetResponse listGroupsWithPost(SearchRequest searchRequest, Map<String, Boolean> requiredAttributes)
             throws NotImplementedException, BadRequestException, CharonException;
 
     default List<Attribute> getCoreSchema() throws CharonException, NotImplementedException, BadRequestException {

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/plainobjects/GroupsGetResponse.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/plainobjects/GroupsGetResponse.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.charon3.core.objects.plainobjects;
+
+import org.wso2.charon3.core.objects.Group;
+
+import java.util.List;
+
+/**
+ * This class representation can be used to create a GroupsGetResponse type object which carries the total number of
+ * groups identified from the filter and the list of groups returned for this request.
+ */
+public class GroupsGetResponse {
+
+    private int totalGroups;
+    private List<Group> groups;
+
+    /**
+     * Constructor used to build a response object when not using cursor pagination.
+     */
+    public GroupsGetResponse(int totalGroups, List<Group> groups) {
+
+        this.totalGroups = totalGroups;
+        this.groups = groups;
+    }
+
+    public int getTotalGroups() {
+
+        return totalGroups;
+    }
+
+    public void setTotalGroups(int totalGroups) {
+
+        this.totalGroups = totalGroups;
+    }
+
+    public List<Group> getGroups() {
+
+        return groups;
+    }
+
+    public void setGroups(List<Group> filteredGroups) {
+
+        this.groups = filteredGroups;
+    }
+}

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/plainobjects/GroupsGetResponse.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/plainobjects/GroupsGetResponse.java
@@ -32,7 +32,7 @@ public class GroupsGetResponse {
     private List<Group> groups;
 
     /**
-     * Constructor used to build a response object when not using cursor pagination.
+     * Constructor used to build a response object.
      */
     public GroupsGetResponse(int totalGroups, List<Group> groups) {
 

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/plainobjects/RolesGetResponse.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/plainobjects/RolesGetResponse.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.charon3.core.objects.plainobjects;
+
+import org.wso2.charon3.core.objects.Role;
+
+import java.util.List;
+
+/**
+ * This class representation can be used to create a RolesGetResponse type object which carries the total number of
+ * roles identified from the filter and the list of roles returned for this request.
+ */
+public class RolesGetResponse {
+
+    private int totalRoles;
+    private List<Role> roles;
+
+    /**
+     * Constructor used to build a response object when not using cursor pagination.
+     */
+    public RolesGetResponse(int totalRoles, List<Role> roles) {
+
+        this.totalRoles = totalRoles;
+        this.roles = roles;
+    }
+
+    public int getTotalRoles() {
+
+        return totalRoles;
+    }
+
+    public void setTotalRoles(int totalRoles) {
+
+        this.totalRoles = totalRoles;
+    }
+
+    public List<Role> getRoles() {
+
+        return roles;
+    }
+
+    public void setRoles (List<Role> filteredRoles) {
+
+        this.roles = filteredRoles;
+    }
+}

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/plainobjects/RolesGetResponse.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/objects/plainobjects/RolesGetResponse.java
@@ -32,7 +32,7 @@ public class RolesGetResponse {
     private List<Role> roles;
 
     /**
-     * Constructor used to build a response object when not using cursor pagination.
+     * Constructor used to build a response object.
      */
     public RolesGetResponse(int totalRoles, List<Role> roles) {
 

--- a/modules/charon-core/src/test/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManagerTest.java
+++ b/modules/charon-core/src/test/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManagerTest.java
@@ -37,6 +37,7 @@ import org.wso2.charon3.core.exceptions.NotFoundException;
 import org.wso2.charon3.core.exceptions.NotImplementedException;
 import org.wso2.charon3.core.extensions.UserManager;
 import org.wso2.charon3.core.objects.Group;
+import org.wso2.charon3.core.objects.plainobjects.GroupsGetResponse;
 import org.wso2.charon3.core.protocol.ResponseCodeConstants;
 import org.wso2.charon3.core.protocol.SCIMResponse;
 import org.wso2.charon3.core.schema.SCIMConstants;
@@ -878,8 +879,7 @@ public class GroupResourceManagerTest {
     @DataProvider(name = "dataForListWithPOST")
     public Object[][] dataToListWithPOST() throws BadRequestException, CharonException, InternalErrorException {
 
-        List<Object> tempList = new ArrayList<>();
-        tempList.add(1);
+        List<Group> tempList = new ArrayList<>();
         tempList.add(getNewGroup());
         return new Object[][]{
                 {RESOURCE_STRING, tempList}
@@ -887,12 +887,13 @@ public class GroupResourceManagerTest {
     }
 
     @Test(dataProvider = "dataForListWithPOST")
-    public void testListWithPOST(String resourceString, List<Object> tempList)
+    public void testListWithPOST(String resourceString, List<Group> tempList)
             throws NotImplementedException, BadRequestException, CharonException {
 
         abstractResourceManager.when(() -> AbstractResourceManager.getResourceEndpointURL(SCIMConstants.USER_ENDPOINT))
                 .thenReturn(SCIM2_GROUP_ENDPOINT + "/.search");
-        Mockito.when(userManager.listGroupsWithPost(any(SearchRequest.class), anyMap())).thenReturn(tempList);
+        Mockito.when(userManager.listGroupsWithPost(any(SearchRequest.class), anyMap()))
+                .thenReturn(new GroupsGetResponse(1, tempList));
         SCIMResponse scimResponse = groupResourceManager.listWithPOST(resourceString, userManager);
         Assert.assertEquals(scimResponse.getResponseStatus(), ResponseCodeConstants.CODE_OK);
     }

--- a/modules/charon-utils/src/main/java/org/wso2/charon3/utils/usermanager/InMemoryUserManager.java
+++ b/modules/charon-utils/src/main/java/org/wso2/charon3/utils/usermanager/InMemoryUserManager.java
@@ -196,8 +196,8 @@ public class InMemoryUserManager implements UserManager {
     }
 
     @Override
-    public GroupsGetResponse listGroupsWithGET(Node rootNode, int startIndex, int count, String sortBy, String sortOrder,
-                                               String domainName, Map<String, Boolean> requiredAttributes)
+    public GroupsGetResponse listGroupsWithGET(Node rootNode, int startIndex, int count, String sortBy,
+                             String sortOrder, String domainName, Map<String, Boolean> requiredAttributes)
             throws CharonException, NotImplementedException, BadRequestException {
         if (sortBy != null || sortOrder != null) {
             throw new NotImplementedException("Sorting is not supported");

--- a/modules/charon-utils/src/main/java/org/wso2/charon3/utils/usermanager/InMemoryUserManager.java
+++ b/modules/charon-utils/src/main/java/org/wso2/charon3/utils/usermanager/InMemoryUserManager.java
@@ -30,6 +30,7 @@ import org.wso2.charon3.core.exceptions.NotImplementedException;
 import org.wso2.charon3.core.extensions.UserManager;
 import org.wso2.charon3.core.objects.Group;
 import org.wso2.charon3.core.objects.User;
+import org.wso2.charon3.core.objects.plainobjects.GroupsGetResponse;
 import org.wso2.charon3.core.utils.CopyUtil;
 import org.wso2.charon3.core.utils.codeutils.Node;
 import org.wso2.charon3.core.utils.codeutils.SearchRequest;
@@ -195,8 +196,8 @@ public class InMemoryUserManager implements UserManager {
     }
 
     @Override
-    public List<Object> listGroupsWithGET(Node rootNode, int startIndex, int count, String sortBy, String sortOrder,
-                                          String domainName, Map<String, Boolean> requiredAttributes)
+    public GroupsGetResponse listGroupsWithGET(Node rootNode, int startIndex, int count, String sortBy, String sortOrder,
+                                               String domainName, Map<String, Boolean> requiredAttributes)
             throws CharonException, NotImplementedException, BadRequestException {
         if (sortBy != null || sortOrder != null) {
             throw new NotImplementedException("Sorting is not supported");
@@ -209,20 +210,12 @@ public class InMemoryUserManager implements UserManager {
         }
     }
 
-    private List<Object> listGroups(Map<String, Boolean> requiredAttributes) {
-        List<Object> groupList = new ArrayList<>();
-        groupList.add(0, 0);
+    private GroupsGetResponse listGroups(Map<String, Boolean> requiredAttributes) {
+        List<Group> groupList = new ArrayList<>();
         for (Group group : inMemoryGroupList.values()) {
             groupList.add(group);
         }
-        groupList.set(0, groupList.size() - 1);
-        try {
-            return (List<Object>) CopyUtil.deepCopy(groupList);
-        } catch (CharonException e) {
-            logger.error("Error in listing groups");
-            return  null;
-        }
-
+        return new GroupsGetResponse(groupList.size(), groupList);
     }
 
     @Override
@@ -237,7 +230,7 @@ public class InMemoryUserManager implements UserManager {
     }
 
     @Override
-    public List<Object> listGroupsWithPost(SearchRequest searchRequest, Map<String, Boolean> requiredAttributes)
+    public GroupsGetResponse listGroupsWithPost(SearchRequest searchRequest, Map<String, Boolean> requiredAttributes)
             throws NotImplementedException, BadRequestException, CharonException {
 
         return listGroupsWithGET(searchRequest.getFilter(), searchRequest.getStartIndex(),


### PR DESCRIPTION
## Purpose
An extension of https://github.com/wso2/charon/pull/371 to make the return type of listGroupsWithGET and listRolesWithGet consistent with the changes made to the return type of listUsersWithGET.

## Goals
The same functionality is maintained while changing the return type from a _List_ to a _custom java object_.

## Related PRs
https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/430

## Test environment
Ubuntu 20.04, WSO2IS-5.12.0-beta2-SNAPSHOT