### PR TITLE
Throw bad request exception for invalid json

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/PatchOperationUtil.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/PatchOperationUtil.java
@@ -3452,7 +3452,7 @@ public class PatchOperationUtil {
      */
     private static AbstractSCIMObject doPatchReplaceOnResource(AbstractSCIMObject oldResource, AbstractSCIMObject
             copyOfOldResource, SCIMResourceTypeSchema schema, JSONDecoder decoder, PatchOperation operation)
-            throws CharonException {
+            throws CharonException, BadRequestException {
 
         try {
             AbstractSCIMObject attributeHoldingSCIMObject = decoder.decode(operation.getValues().toString(), schema);
@@ -3609,7 +3609,7 @@ public class PatchOperationUtil {
             } else  {
                 throw new CharonException("Error in getting the old resource.");
             }
-        } catch (BadRequestException | CharonException e) {
+        } catch (CharonException e) {
             throw new CharonException("Error in performing the replace operation", e);
         }
     }


### PR DESCRIPTION
## Purpose
Capture null values in the request and throw BadRequest 400 status instead of 500 ServerError.
- Sample request: PATCH https://localhost:9443/scim2/Me
- Sample payload (Note the null value between two emails)
`{"Operations":[{"op":"replace","value":{"emails":[{"type":"work","value":"test@gmail.com"},null,{"type":"other","value":"test2@gmail.com"}]}}],"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"]}`
- Response (Before the fix)
`{"schemas":["urn:ietf:params:scim:api:messages:2.0:Error"],"detail":"Error in performing the replace operation","status":"500"}`
- Response (After the fix)
`{"schemas":["urn:ietf:params:scim:api:messages:2.0:Error"],"scimType":"invalidSyntax","detail":"Request is unparsable, syntactically incorrect, or violates schema.","status":"400"}`

Fixes https://github.com/wso2/product-is/issues/14477

