### PR TITLE
Fix: Use the correct description text when throwing a ForbiddenException

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/exceptions/ForbiddenException.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/exceptions/ForbiddenException.java
@@ -23,7 +23,7 @@ import org.wso2.charon3.core.protocol.ResponseCodeConstants;
 public class ForbiddenException extends AbstractCharonException {
 
     public ForbiddenException() {
-        this(ResponseCodeConstants.DESC_CONFLICT);
+        this(ResponseCodeConstants.DESC_FORBIDDEN);
     }
 
     public ForbiddenException(String exception) {


### PR DESCRIPTION
## Purpose

Fix: Use the correct description text when throwing a `ForbiddenException`
