### PR TITLE
Enable loading the UserSchemaExtension from a classpath resource

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/config/SCIMUserSchemaExtensionBuilder.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/config/SCIMUserSchemaExtensionBuilder.java
@@ -56,13 +56,30 @@ public class SCIMUserSchemaExtensionBuilder extends ExtensionBuilder {
         return extensionSchema;
     }
 
+    public void buildUserSchemaExtension(String configFilePath) throws CharonException, InternalErrorException {
+
+        File provisioningConfig = new File(configFilePath);
+
+        try (InputStream inputStream = new FileInputStream(provisioningConfig)) {
+
+            buildUserSchemaExtension(inputStream);
+
+        } catch (FileNotFoundException e) {
+            throw new CharonException(SCIMConfigConstants.SCIM_SCHEMA_EXTENSION_CONFIG + " file not found!",
+                    e);
+        } catch (IOException e) {
+            throw new CharonException("Error while closing " +
+                    SCIMConfigConstants.SCIM_SCHEMA_EXTENSION_CONFIG + " file!", e);
+        }
+    }
+
     /*
      * Logic goes here
      * @throws CharonException
      */
-    public void buildUserSchemaExtension(String configFilePath) throws CharonException, InternalErrorException {
+    public void buildUserSchemaExtension(InputStream inputStream) throws CharonException, InternalErrorException {
 
-        readConfiguration(configFilePath);
+        readConfiguration(inputStream);
 
         for (Map.Entry<String, ExtensionAttributeSchemaConfig> attributeSchemaConfig : extensionConfig.entrySet()) {
             // if there are no children its a simple attribute, build it
@@ -88,11 +105,9 @@ public class SCIMUserSchemaExtensionBuilder extends ExtensionBuilder {
      * @param configFilePath
      * @throws CharonException
      */
-    private void readConfiguration(String configFilePath) throws CharonException {
+    private void readConfiguration(InputStream inputStream) throws CharonException {
 
-        File provisioningConfig = new File(configFilePath);
-        try (InputStream inputStream = new FileInputStream(provisioningConfig)) {
-            //Scanner scanner = new Scanner(new FileInputStream(provisioningConfig));
+        try {
             Scanner scanner = new Scanner(inputStream, "utf-8").useDelimiter("\\A");
             String jsonString = scanner.hasNext() ? scanner.next() : "";
 
@@ -112,14 +127,8 @@ public class SCIMUserSchemaExtensionBuilder extends ExtensionBuilder {
                     extensionRootAttributeName = schemaAttributeConfig.getName();
                 }
             }
-        } catch (FileNotFoundException e) {
-            throw new CharonException(SCIMConfigConstants.SCIM_SCHEMA_EXTENSION_CONFIG + " file not found!",
-                    e);
         } catch (JSONException e) {
             throw new CharonException("Error while parsing " +
-                    SCIMConfigConstants.SCIM_SCHEMA_EXTENSION_CONFIG + " file!", e);
-        } catch (IOException e) {
-            throw new CharonException("Error while closing " +
                     SCIMConfigConstants.SCIM_SCHEMA_EXTENSION_CONFIG + " file!", e);
         }
     }


### PR DESCRIPTION
## Purpose

When using Charon in the context of a Spring Boot application, typically all resources needed by the application are packaged into the jar file together with all of the application's classes. In this case, it is not directly possible to read that classpath resource via a `FileInputStream`. In order to still be able to load a UserSchemaExtension, currently a workaround would need to applied in the application, i.e. the classpath resource would need to be copied to a temporary file, and then the temporary file would need to be deleted after being loaded by `SCIMUserSchemaExtensionBuilder`.

## Goals

In order to avoid this workaround, I added a further method to `SCIMUserSchemaExtensionBuilder` which it loads the schema from any `InputStream`. When using this newly introduced method, the application is responsible for opening and closing that stream (and handling the exceptions that may appear during opening and closing).

The solution is fully backwards compatible, i.e. the previous method signature `buildUserSchemaExtension(String configFilePath)` is still available, and it behaves the same as before. Only a new method `buildUserSchemaExtension(InputStream inputStream)` has been made available.
