### PR TITLE
Fix Getting 500 error response for client errors in SCIM/Groups PATCH

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
@@ -932,13 +932,29 @@ public class GroupResourceManager extends AbstractResourceManager {
     }
 
     private List<Map<String, String>> transformMembersAttributeToMap(MultiValuedAttribute multiValuedMembersAttribute)
-            throws CharonException {
+            throws CharonException, BadRequestException {
 
         List<Map<String, String>> memberList = new ArrayList<>();
         List<Attribute> subValuesList = multiValuedMembersAttribute.getAttributeValues();
         for (Attribute subValue : subValuesList) {
             ComplexAttribute complexAttribute = (ComplexAttribute) subValue;
             Map<String, Attribute> subAttributesList = complexAttribute.getSubAttributesList();
+
+            // Check if `value` (member id) attribute is present and not empty.
+            if (!subAttributesList.containsKey(SCIMConstants.CommonSchemaConstants.VALUE)) {
+                throw new BadRequestException(ResponseCodeConstants.DESC_BAD_REQUEST,
+                        ResponseCodeConstants.INVALID_SYNTAX);
+            } else if (((SimpleAttribute)
+                    (subAttributesList.get(SCIMConstants.CommonSchemaConstants.VALUE))).getStringValue().isEmpty()) {
+                throw new BadRequestException(ResponseCodeConstants.DESC_BAD_REQUEST,
+                        ResponseCodeConstants.INVALID_VALUE);
+            }
+
+            // Check if `display` value is present.
+            if (!subAttributesList.containsKey(SCIMConstants.CommonSchemaConstants.DISPLAY)) {
+                throw new BadRequestException(ResponseCodeConstants.DESC_BAD_REQUEST,
+                        ResponseCodeConstants.INVALID_SYNTAX);
+            }
 
             Map<String, String> member = new HashMap<>();
             member.put(SCIMConstants.CommonSchemaConstants.VALUE, ((SimpleAttribute)

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
@@ -941,21 +941,14 @@ public class GroupResourceManager extends AbstractResourceManager {
             ComplexAttribute complexAttribute = (ComplexAttribute) subValue;
             Map<String, Attribute> subAttributesList = complexAttribute.getSubAttributesList();
 
-            // Check if `value` (member id) attribute is present and not empty.
-            // Check if `value` (member id) attribute is present and not empty.
-            if (!subAttributesList.containsKey(SCIMConstants.CommonSchemaConstants.VALUE)) {
+            if (!subAttributesList.containsKey(SCIMConstants.CommonSchemaConstants.VALUE) ||
+                    !subAttributesList.containsKey(SCIMConstants.CommonSchemaConstants.DISPLAY)) {
                 throw new BadRequestException(ResponseCodeConstants.DESC_BAD_REQUEST,
                         ResponseCodeConstants.INVALID_SYNTAX);
             } else if (StringUtils.isEmpty(((SimpleAttribute)
                         subAttributesList.get(SCIMConstants.CommonSchemaConstants.VALUE)).getStringValue())) {
                 throw new BadRequestException(ResponseCodeConstants.DESC_BAD_REQUEST,
                         ResponseCodeConstants.INVALID_VALUE);
-            }
-
-            // Check if `display` value is present.
-            if (!subAttributesList.containsKey(SCIMConstants.CommonSchemaConstants.DISPLAY)) {
-                throw new BadRequestException(ResponseCodeConstants.DESC_BAD_REQUEST,
-                        ResponseCodeConstants.INVALID_SYNTAX);
             }
 
             Map<String, String> member = new HashMap<>();

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
@@ -944,8 +944,7 @@ public class GroupResourceManager extends AbstractResourceManager {
             if (!subAttributesList.containsKey(SCIMConstants.CommonSchemaConstants.VALUE) ||
                     !subAttributesList.containsKey(SCIMConstants.CommonSchemaConstants.DISPLAY)) {
                 throw new BadRequestException(ResponseCodeConstants.INVALID_SYNTAX);
-            }
-            else if (StringUtils.isEmpty(((SimpleAttribute)
+            } else if (StringUtils.isEmpty(((SimpleAttribute)
                         subAttributesList.get(SCIMConstants.CommonSchemaConstants.VALUE)).getStringValue())) {
                 throw new BadRequestException(ResponseCodeConstants.INVALID_VALUE);
             }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
@@ -15,6 +15,7 @@
  */
 package org.wso2.charon3.core.protocol.endpoints;
 
+import org.apache.commons.lang.StringUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -941,13 +942,17 @@ public class GroupResourceManager extends AbstractResourceManager {
             Map<String, Attribute> subAttributesList = complexAttribute.getSubAttributesList();
 
             // Check if `value` (member id) attribute is present and not empty.
+            // Check if `value` (member id) attribute is present and not empty.
             if (!subAttributesList.containsKey(SCIMConstants.CommonSchemaConstants.VALUE)) {
                 throw new BadRequestException(ResponseCodeConstants.DESC_BAD_REQUEST,
                         ResponseCodeConstants.INVALID_SYNTAX);
-            } else if (((SimpleAttribute)
-                    (subAttributesList.get(SCIMConstants.CommonSchemaConstants.VALUE))).getStringValue().isEmpty()) {
-                throw new BadRequestException(ResponseCodeConstants.DESC_BAD_REQUEST,
-                        ResponseCodeConstants.INVALID_VALUE);
+            } else {
+                SimpleAttribute valueAttribute = (SimpleAttribute)
+                        subAttributesList.get(SCIMConstants.CommonSchemaConstants.VALUE);
+                if (StringUtils.isEmpty(valueAttribute.getStringValue())) {
+                    throw new BadRequestException(ResponseCodeConstants.DESC_BAD_REQUEST,
+                            ResponseCodeConstants.INVALID_VALUE);
+                }
             }
 
             // Check if `display` value is present.

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
@@ -946,12 +946,10 @@ public class GroupResourceManager extends AbstractResourceManager {
             if (!subAttributesList.containsKey(SCIMConstants.CommonSchemaConstants.VALUE)) {
                 throw new BadRequestException(ResponseCodeConstants.DESC_BAD_REQUEST,
                         ResponseCodeConstants.INVALID_SYNTAX);
-            } else {
-                if (StringUtils.isEmpty(((SimpleAttribute)
+            } else if (StringUtils.isEmpty(((SimpleAttribute)
                         subAttributesList.get(SCIMConstants.CommonSchemaConstants.VALUE)).getStringValue())) {
-                    throw new BadRequestException(ResponseCodeConstants.DESC_BAD_REQUEST,
-                            ResponseCodeConstants.INVALID_VALUE);
-                }
+                throw new BadRequestException(ResponseCodeConstants.DESC_BAD_REQUEST,
+                        ResponseCodeConstants.INVALID_VALUE);
             }
 
             // Check if `display` value is present.

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
@@ -943,12 +943,11 @@ public class GroupResourceManager extends AbstractResourceManager {
 
             if (!subAttributesList.containsKey(SCIMConstants.CommonSchemaConstants.VALUE) ||
                     !subAttributesList.containsKey(SCIMConstants.CommonSchemaConstants.DISPLAY)) {
-                throw new BadRequestException(ResponseCodeConstants.DESC_BAD_REQUEST,
-                        ResponseCodeConstants.INVALID_SYNTAX);
-            } else if (StringUtils.isEmpty(((SimpleAttribute)
+                throw new BadRequestException(ResponseCodeConstants.INVALID_SYNTAX);
+            }
+            else if (StringUtils.isEmpty(((SimpleAttribute)
                         subAttributesList.get(SCIMConstants.CommonSchemaConstants.VALUE)).getStringValue())) {
-                throw new BadRequestException(ResponseCodeConstants.DESC_BAD_REQUEST,
-                        ResponseCodeConstants.INVALID_VALUE);
+                throw new BadRequestException(ResponseCodeConstants.INVALID_VALUE);
             }
 
             Map<String, String> member = new HashMap<>();

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
@@ -947,9 +947,8 @@ public class GroupResourceManager extends AbstractResourceManager {
                 throw new BadRequestException(ResponseCodeConstants.DESC_BAD_REQUEST,
                         ResponseCodeConstants.INVALID_SYNTAX);
             } else {
-                SimpleAttribute valueAttribute = (SimpleAttribute)
-                        subAttributesList.get(SCIMConstants.CommonSchemaConstants.VALUE);
-                if (StringUtils.isEmpty(valueAttribute.getStringValue())) {
+                if (StringUtils.isEmpty(((SimpleAttribute)
+                        subAttributesList.get(SCIMConstants.CommonSchemaConstants.VALUE)).getStringValue())) {
                     throw new BadRequestException(ResponseCodeConstants.DESC_BAD_REQUEST,
                             ResponseCodeConstants.INVALID_VALUE);
                 }


### PR DESCRIPTION
## Purpose
This PR aims to address the issues mentioned in [https://github.com/wso2/product-is/issues/16097](https://github.com/wso2/product-is/issues/16097).

## Goals
The goals of this PR are to:
- Change the error responses when adding a member to a group with only a display name.
- Change the error responses when adding a member to a group with only an ID.
- Change the error responses where a user is added with an empty ID.

## Approach
To achieve the above goals, I have added check for `display` (display name) and  `value` (ID). 

## Scenarios
### Add a member to a group with only display name
**Old Response:**
```
{
    "schemas": [
        "urn:ietf:params:scim:api:messages:2.0:Error"
    ],
    "detail": "Error in performing the patch operation on group resource.",
    "status": "500"
}
```
**New Response:**
```
{
    "schemas": [
        "urn:ietf:params:scim:api:messages:2.0:Error"
    ],
    "scimType": "invalidSyntax",
    "detail": "Request is unparsable, syntactically incorrect, or violates schema.",
    "status": "400"
}
```

### Add a member to a group with only id
**Old Response:**
```
{
    "schemas": [
        "urn:ietf:params:scim:api:messages:2.0:Error"
    ],
    "detail": "Error in performing the patch operation on group resource.",
    "status": "500"
}
```
**New Response:**
```
{
    "schemas": [
        "urn:ietf:params:scim:api:messages:2.0:Error"
    ],
    "scimType": "invalidSyntax",
    "detail": "Request is unparsable, syntactically incorrect, or violates schema.",
    "status": "400"
}
```

### Add user with empty id
**Old Response:**
```
{
    "schemas": [
        "urn:ietf:params:scim:api:messages:2.0:Error"
    ],
    "detail": "Error in performing the patch operation on group resource.",
    "status": "500"
}
```
**New Response:**
```
{
    "schemas": [
        "urn:ietf:params:scim:api:messages:2.0:Error"
    ],
    "scimType": "invalidValue",
    "detail": "Request is unparsable, syntactically incorrect, or violates schema.",
    "status": "400"
}
```
