### PR TITLE
Support scim group patch call when only value attribute is present for members.

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
@@ -941,19 +941,24 @@ public class GroupResourceManager extends AbstractResourceManager {
             ComplexAttribute complexAttribute = (ComplexAttribute) subValue;
             Map<String, Attribute> subAttributesList = complexAttribute.getSubAttributesList();
 
-            if (!subAttributesList.containsKey(SCIMConstants.CommonSchemaConstants.VALUE) ||
+            if (!subAttributesList.containsKey(SCIMConstants.CommonSchemaConstants.VALUE) &&
                     !subAttributesList.containsKey(SCIMConstants.CommonSchemaConstants.DISPLAY)) {
                 throw new BadRequestException(ResponseCodeConstants.INVALID_SYNTAX);
+            } else if (!subAttributesList.containsKey(SCIMConstants.CommonSchemaConstants.VALUE)) {
+                throw new BadRequestException("Value attribute is required for the members attribute.",
+                        ResponseCodeConstants.INVALID_SYNTAX);
             } else if (StringUtils.isEmpty(((SimpleAttribute)
-                        subAttributesList.get(SCIMConstants.CommonSchemaConstants.VALUE)).getStringValue())) {
+                    subAttributesList.get(SCIMConstants.CommonSchemaConstants.VALUE)).getStringValue())) {
                 throw new BadRequestException(ResponseCodeConstants.INVALID_VALUE);
             }
 
             Map<String, String> member = new HashMap<>();
+            if (subAttributesList.containsKey(SCIMConstants.CommonSchemaConstants.DISPLAY)) {
+                member.put(SCIMConstants.CommonSchemaConstants.DISPLAY, ((SimpleAttribute)
+                        (subAttributesList.get(SCIMConstants.CommonSchemaConstants.DISPLAY))).getStringValue());
+            }
             member.put(SCIMConstants.CommonSchemaConstants.VALUE, ((SimpleAttribute)
                     (subAttributesList.get(SCIMConstants.CommonSchemaConstants.VALUE))).getStringValue());
-            member.put(SCIMConstants.CommonSchemaConstants.DISPLAY, ((SimpleAttribute)
-                    (subAttributesList.get(SCIMConstants.CommonSchemaConstants.DISPLAY))).getStringValue());
             memberList.add(member);
         }
         return memberList;


### PR DESCRIPTION
Currently, we expect both `display` and `value` attributes to be present to update a group with a user during an add operation. With this implementation, the display attribute is made optional and a group can be updated with a user by providing the userId as the value for the value attribute.

Related issue:
- https://github.com/wso2/product-is/issues/16451