### PR TITLE
Add support for bulkID in SCIM2

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONDecoder.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONDecoder.java
@@ -926,7 +926,6 @@ public class JSONDecoder {
                     if (StringUtils.isNotEmpty(bulkId)) {
                         if (encounteredBulkIds.contains(bulkId)) {
                             String error = "Duplicate bulkId found: " + bulkId;
-                            logger.error(error);
                             throw new BadRequestException(error, ResponseCodeConstants.INVALID_VALUE);
                         }
                         encounteredBulkIds.add(bulkId);

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONDecoder.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONDecoder.java
@@ -15,6 +15,7 @@
  */
 package org.wso2.charon3.core.encoder;
 
+import org.apache.commons.lang.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -53,8 +54,10 @@ import org.wso2.charon3.core.utils.codeutils.SearchRequest;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.wso2.charon3.core.schema.SCIMDefinitions.DataType.BINARY;
 import static org.wso2.charon3.core.schema.SCIMDefinitions.DataType.BOOLEAN;
@@ -881,6 +884,7 @@ public class JSONDecoder {
         List<BulkRequestContent> rolesEndpointOperationList = new ArrayList<>();
         int failOnErrorsAttribute;
         List<String> schemas = new ArrayList<>();
+        Set<String> encounteredBulkIds = new HashSet<>();
 
         JSONObject decodedObject;
         try {
@@ -917,9 +921,15 @@ public class JSONDecoder {
 
                 if (requestMethod.equals(SCIMConstants.OperationalConstants.POST)) {
 
-                    if (!member.optString(SCIMConstants.OperationalConstants.BULK_ID).equals("") &&
-                            member.optString(SCIMConstants.OperationalConstants.BULK_ID) != null) {
+                    String bulkId = member.optString(SCIMConstants.OperationalConstants.BULK_ID);
 
+                    if (StringUtils.isNotEmpty(bulkId)) {
+                        if (encounteredBulkIds.contains(bulkId)) {
+                            String error = "Duplicate bulkId found: " + bulkId;
+                            logger.error(error);
+                            throw new BadRequestException(error, ResponseCodeConstants.INVALID_VALUE);
+                        }
+                        encounteredBulkIds.add(bulkId);
                         setRequestData(requestType, requestMethod, requestVersion, member, usersEndpointOperationList,
                                 groupsEndpointOperationList, rolesEndpointOperationList);
                     } else {

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/BulkRequestProcessor.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/BulkRequestProcessor.java
@@ -17,6 +17,7 @@
 */
 package org.wso2.charon3.core.protocol;
 
+import org.apache.commons.lang.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -310,7 +311,7 @@ public class BulkRequestProcessor {
                     if (userValue.startsWith(bulkIdPrefix)) {
                         String userBulkId = userValue.substring(bulkIdPrefix.length());
                         String userId = userIDMappings.get(userBulkId);
-                        if (userId != null) {
+                        if (StringUtils.isNotBlank(userId)) {
                             user.put(SCIMConstants.OperationalConstants.VALUE, userId);
                         }
                     }
@@ -332,12 +333,12 @@ public class BulkRequestProcessor {
 
     /**
      * This method is used to get the user array from the data JSON object.
-     * @param dataJson          SCIM data JSON object
-     * @param method            HTTP method
-     * @param usersOrMembersKey Users or members key
      *
+     * @param dataJson          SCIM data JSON object.
+     * @param method            HTTP method.
+     * @param usersOrMembersKey Users or members key.
      * @return User array
-     * @throws JSONException    JSON exception
+     * @throws JSONException    JSON exception.
      */
     private JSONArray getUserArray(JSONObject dataJson, String method, String usersOrMembersKey)
             throws JSONException {
@@ -385,8 +386,8 @@ public class BulkRequestProcessor {
 
     /**
      * This method is used to get user id bulk id mapping from the bulk user operation response.
-     * @param bulkUserOperationResponse Bulk user operation response.
      *
+     * @param bulkUserOperationResponse Bulk user operation response.
      * @return Bulk id user id mapping.
      */
     private static Map<String, String> getUserIdBulkIdMapping(List<BulkResponseContent> bulkUserOperationResponse) {

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/BulkRequestProcessor.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/BulkRequestProcessor.java
@@ -51,7 +51,6 @@ public class BulkRequestProcessor {
     private UserManager userManager;
     private RoleManager roleManager;
 
-
     public UserResourceManager getUserResourceManager() {
         return userResourceManager;
     }
@@ -129,12 +128,10 @@ public class BulkRequestProcessor {
 
         for (BulkRequestContent bulkRequestContent : bulkRequestData.getUserOperationRequests()) {
             if (failOnError == 0) {
-                bulkResponseData.addUserOperation
-                            (getBulkResponseContent(bulkRequestContent, userResourceManager));
+                bulkResponseData.addUserOperation(getBulkResponseContent(bulkRequestContent, userResourceManager));
             } else {
                 if (errors < failOnError) {
-                    bulkResponseData.addUserOperation
-                            (getBulkResponseContent(bulkRequestContent, userResourceManager));
+                    bulkResponseData.addUserOperation(getBulkResponseContent(bulkRequestContent, userResourceManager));
                 }
             }
 
@@ -143,14 +140,12 @@ public class BulkRequestProcessor {
 
         for (BulkRequestContent bulkRequestContent : bulkRequestData.getGroupOperationRequests()) {
             if (failOnError == 0) {
-                bulkResponseData.addGroupOperation
-                            (getBulkResponseContent(bulkRequestContent,
-                                    userIdMappings, groupResourceManager));
+                bulkResponseData.addGroupOperation(
+                        getBulkResponseContent(bulkRequestContent, userIdMappings, groupResourceManager));
             } else  {
                 if (errors < failOnError) {
-                    bulkResponseData.addGroupOperation
-                            (getBulkResponseContent(bulkRequestContent,
-                                    userIdMappings, groupResourceManager));
+                    bulkResponseData.addGroupOperation(
+                            getBulkResponseContent(bulkRequestContent, userIdMappings, groupResourceManager));
                 }
             }
 
@@ -176,77 +171,77 @@ public class BulkRequestProcessor {
         return getBulkResponseContent(bulkRequestContent, null, resourceManager);
     }
 
-   private BulkResponseContent getBulkResponseContent(BulkRequestContent bulkRequestContent,
-                                                      Map<String, String> userIdMappings,
-                                                      ResourceManager resourceManager)
-           throws BadRequestException {
+    private BulkResponseContent getBulkResponseContent(BulkRequestContent bulkRequestContent,
+                                                       Map<String, String> userIdMappings,
+                                                       ResourceManager resourceManager)
+            throws BadRequestException {
 
-       BulkResponseContent bulkResponseContent = null;
-       SCIMResponse response;
-       processBulkRequestContent(bulkRequestContent, userIdMappings, bulkRequestContent.getMethod());
+        BulkResponseContent bulkResponseContent = null;
+        SCIMResponse response;
+        processBulkRequestContent(bulkRequestContent, userIdMappings, bulkRequestContent.getMethod());
 
-       switch (bulkRequestContent.getMethod()) {
-           case SCIMConstants.OperationalConstants.POST:
-               if (bulkRequestContent.getPath().contains(SCIMConstants.ROLE_ENDPOINT)) {
-                   response = resourceManager.createRole(bulkRequestContent.getData(), roleManager);
-               } else {
-                   response = resourceManager.create(bulkRequestContent.getData(), userManager,
-                           null, null);
-               }
+        switch (bulkRequestContent.getMethod()) {
+            case SCIMConstants.OperationalConstants.POST:
+                if (bulkRequestContent.getPath().contains(SCIMConstants.ROLE_ENDPOINT)) {
+                    response = resourceManager.createRole(bulkRequestContent.getData(), roleManager);
+                } else {
+                    response = resourceManager.create(bulkRequestContent.getData(), userManager,
+                            null, null);
+                }
 
-               bulkResponseContent = createBulkResponseContent(response, SCIMConstants.OperationalConstants.POST,
-                       bulkRequestContent);
-               errorsCheck(response);
-               break;
+                bulkResponseContent = createBulkResponseContent(response, SCIMConstants.OperationalConstants.POST,
+                        bulkRequestContent);
+                errorsCheck(response);
+                break;
 
-           case SCIMConstants.OperationalConstants.PUT: {
-               String resourceId = extractIDFromPath(bulkRequestContent.getPath());
-               if (bulkRequestContent.getPath().contains(SCIMConstants.ROLE_ENDPOINT)) {
-                   response = resourceManager.updateWithPUTRole(resourceId, bulkRequestContent.getData(),
-                           roleManager);
-               } else {
-                   response = resourceManager.updateWithPUT(resourceId, bulkRequestContent.getData(), userManager,
-                                   null, null);
-               }
+            case SCIMConstants.OperationalConstants.PUT: {
+                String resourceId = extractIDFromPath(bulkRequestContent.getPath());
+                if (bulkRequestContent.getPath().contains(SCIMConstants.ROLE_ENDPOINT)) {
+                    response = resourceManager.updateWithPUTRole(resourceId, bulkRequestContent.getData(),
+                            roleManager);
+                } else {
+                    response = resourceManager.updateWithPUT(resourceId, bulkRequestContent.getData(), userManager,
+                            null, null);
+                }
 
-               bulkResponseContent = createBulkResponseContent(response, SCIMConstants.OperationalConstants.PUT,
-                       bulkRequestContent);
-               errorsCheck(response);
-               break;
-           }
+                bulkResponseContent = createBulkResponseContent(response, SCIMConstants.OperationalConstants.PUT,
+                        bulkRequestContent);
+                errorsCheck(response);
+                break;
+            }
 
-           case SCIMConstants.OperationalConstants.PATCH: {
-               String resourceId = extractIDFromPath(bulkRequestContent.getPath());
-               if (bulkRequestContent.getPath().contains(SCIMConstants.ROLE_ENDPOINT)) {
-                   response = resourceManager.updateWithPATCHRole(resourceId, bulkRequestContent.getData(),
-                           roleManager);
-               } else {
-                   response = resourceManager.updateWithPATCH(resourceId, bulkRequestContent.getData(), userManager,
-                                   null, null);
-               }
+            case SCIMConstants.OperationalConstants.PATCH: {
+                String resourceId = extractIDFromPath(bulkRequestContent.getPath());
+                if (bulkRequestContent.getPath().contains(SCIMConstants.ROLE_ENDPOINT)) {
+                    response = resourceManager.updateWithPATCHRole(resourceId, bulkRequestContent.getData(),
+                            roleManager);
+                } else {
+                    response = resourceManager.updateWithPATCH(resourceId, bulkRequestContent.getData(), userManager,
+                            null, null);
+                }
 
-               bulkResponseContent = createBulkResponseContent(response, SCIMConstants.OperationalConstants.PATCH,
-                       bulkRequestContent);
-               errorsCheck(response);
-               break;
-           }
+                bulkResponseContent = createBulkResponseContent(response, SCIMConstants.OperationalConstants.PATCH,
+                        bulkRequestContent);
+                errorsCheck(response);
+                break;
+            }
 
-           case SCIMConstants.OperationalConstants.DELETE: {
-               String resourceId = extractIDFromPath(bulkRequestContent.getPath());
-               if (bulkRequestContent.getPath().contains(SCIMConstants.ROLE_ENDPOINT)) {
-                   response = resourceManager.deleteRole(resourceId, roleManager);
-               } else {
-                   response = resourceManager.delete(resourceId, userManager);
-               }
+            case SCIMConstants.OperationalConstants.DELETE: {
+                String resourceId = extractIDFromPath(bulkRequestContent.getPath());
+                if (bulkRequestContent.getPath().contains(SCIMConstants.ROLE_ENDPOINT)) {
+                    response = resourceManager.deleteRole(resourceId, roleManager);
+                } else {
+                    response = resourceManager.delete(resourceId, userManager);
+                }
 
-               bulkResponseContent = createBulkResponseContent(response, SCIMConstants.OperationalConstants.DELETE,
-                       bulkRequestContent);
-               errorsCheck(response);
-               break;
-           }
-       }
-       return bulkResponseContent;
-   }
+                bulkResponseContent = createBulkResponseContent(response, SCIMConstants.OperationalConstants.DELETE,
+                        bulkRequestContent);
+                errorsCheck(response);
+                break;
+            }
+        }
+        return bulkResponseContent;
+    }
 
     private String extractIDFromPath(String path) throws BadRequestException {
 
@@ -294,17 +289,18 @@ public class BulkRequestProcessor {
                                            String method) throws BadRequestException {
 
         try {
-            if (userIDMappings == null || userIDMappings.isEmpty()
-                    || method.equals(SCIMConstants.OperationalConstants.DELETE)) {
+            if (userIDMappings == null || userIDMappings.isEmpty() ||
+                    method.equals(SCIMConstants.OperationalConstants.DELETE)) {
                 return;
             }
-            // Parse the data field to a JSON object.
+
             JSONObject dataJson = new JSONObject(bulkRequestContent.getData());
             String usersOrMembersKey = getUsersOrMembersKey(bulkRequestContent.getPath());
             JSONArray usersArray = getUserArray(dataJson, method, usersOrMembersKey);
 
             if (usersArray != null) {
-                String bulkIdPrefix = SCIMConstants.OperationalConstants.BULK_ID + ":";
+                String bulkIdPrefix =
+                        SCIMConstants.OperationalConstants.BULK_ID + SCIMConstants.OperationalConstants.COLON;
                 for (int i = 0; i < usersArray.length(); i++) {
                     JSONObject user = usersArray.getJSONObject(i);
                     String userValue = user.getString(SCIMConstants.OperationalConstants.VALUE);
@@ -336,37 +332,32 @@ public class BulkRequestProcessor {
      * @param dataJson          SCIM data JSON object.
      * @param method            HTTP method.
      * @param usersOrMembersKey Users or members key.
-     * @return User array
+     * @return User array.
      * @throws JSONException    JSON exception.
      */
-    private JSONArray getUserArray(JSONObject dataJson, String method, String usersOrMembersKey)
-            throws JSONException {
+    private JSONArray getUserArray(JSONObject dataJson, String method, String usersOrMembersKey) throws JSONException {
 
-        switch (method) {
-            case SCIMConstants.OperationalConstants.POST:
-            case SCIMConstants.OperationalConstants.PUT:
-                return dataJson.optJSONArray(usersOrMembersKey);
-            case SCIMConstants.OperationalConstants.PATCH:
-                return getUserArrayForPatch(dataJson, usersOrMembersKey);
-            default:
-                return null;
+        if (SCIMConstants.OperationalConstants.PATCH.equals(method)) {
+            return getUserArrayForPatch(dataJson, usersOrMembersKey);
         }
+        return dataJson.optJSONArray(usersOrMembersKey);
     }
 
     private JSONArray getUserArrayForPatch(JSONObject dataJson, String usersOrMembersKey) throws JSONException {
 
         JSONArray operations = dataJson.optJSONArray(SCIMConstants.OperationalConstants.OPERATIONS);
-        if (operations != null) {
-            for (int i = 0; i < operations.length(); i++) {
-                JSONObject operation = operations.getJSONObject(i);
-                if (isAddOperation(operation, usersOrMembersKey)) {
-                    if (operation.has(SCIMConstants.OperationalConstants.PATH)) {
-                        return operation.optJSONArray(SCIMConstants.OperationalConstants.VALUE);
-                    } else {
-                        JSONObject valueObject = operation.optJSONObject(SCIMConstants.OperationalConstants.VALUE);
-                        if (valueObject != null) {
-                            return valueObject.optJSONArray(usersOrMembersKey);
-                        }
+        if (operations == null) {
+            return null;
+        }
+        for (int i = 0; i < operations.length(); i++) {
+            JSONObject operation = operations.getJSONObject(i);
+            if (isValidOperation(operation, usersOrMembersKey)) {
+                if (operation.has(SCIMConstants.OperationalConstants.PATH)) {
+                    return operation.optJSONArray(SCIMConstants.OperationalConstants.VALUE);
+                } else {
+                    JSONObject valueObject = operation.optJSONObject(SCIMConstants.OperationalConstants.VALUE);
+                    if (valueObject != null) {
+                        return valueObject.optJSONArray(usersOrMembersKey);
                     }
                 }
             }
@@ -374,12 +365,13 @@ public class BulkRequestProcessor {
         return null;
     }
 
-    private boolean isAddOperation(JSONObject operation, String path) throws JSONException {
+    private boolean isValidOperation(JSONObject operation, String path) throws JSONException {
 
         String operationType = operation.optString(SCIMConstants.OperationalConstants.OP);
-        String operationPath = operation.optString(SCIMConstants.OperationalConstants.PATH, "");
+        String operationPath = operation.optString(SCIMConstants.OperationalConstants.PATH, StringUtils.EMPTY);
 
-        return SCIMConstants.OperationalConstants.ADD.equalsIgnoreCase(operationType) &&
+        return (SCIMConstants.OperationalConstants.ADD.equalsIgnoreCase(operationType) ||
+                SCIMConstants.OperationalConstants.REPLACE.equalsIgnoreCase(operationType)) &&
                 (operationPath.equals(path) || operationPath.isEmpty());
     }
 
@@ -400,7 +392,8 @@ public class BulkRequestProcessor {
                 String locationHeader = response.getHeaderParamMap().get(SCIMConstants.LOCATION_HEADER);
 
                 if (locationHeader != null) {
-                    String[] locationHeaderParts = locationHeader.split("/");
+                    String[] locationHeaderParts =
+                            locationHeader.split(SCIMConstants.OperationalConstants.URL_SEPARATOR);
                     String userId = locationHeaderParts[locationHeaderParts.length - 1];
                     userIdMappings.put(bulkId, userId);
                 }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/BulkRequestProcessor.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/BulkRequestProcessor.java
@@ -290,7 +290,7 @@ public class BulkRequestProcessor {
 
         try {
             if (userIDMappings == null || userIDMappings.isEmpty() ||
-                    method.equals(SCIMConstants.OperationalConstants.DELETE)) {
+                    SCIMConstants.OperationalConstants.DELETE.equals(method)) {
                 return;
             }
 
@@ -354,11 +354,10 @@ public class BulkRequestProcessor {
             if (isValidOperation(operation, usersOrMembersKey)) {
                 if (operation.has(SCIMConstants.OperationalConstants.PATH)) {
                     return operation.optJSONArray(SCIMConstants.OperationalConstants.VALUE);
-                } else {
-                    JSONObject valueObject = operation.optJSONObject(SCIMConstants.OperationalConstants.VALUE);
-                    if (valueObject != null) {
-                        return valueObject.optJSONArray(usersOrMembersKey);
-                    }
+                }
+                JSONObject valueObject = operation.optJSONObject(SCIMConstants.OperationalConstants.VALUE);
+                if (valueObject != null) {
+                    return valueObject.optJSONArray(usersOrMembersKey);
                 }
             }
         }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/BulkRequestProcessor.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/BulkRequestProcessor.java
@@ -169,20 +169,19 @@ public class BulkRequestProcessor {
         return bulkResponseData;
     }
 
-    private BulkResponseContent getBulkResponseContent
-            (BulkRequestContent bulkRequestContent, ResourceManager resourceManager)
-            throws BadRequestException {
+    private BulkResponseContent getBulkResponseContent(BulkRequestContent bulkRequestContent,
+                                                       ResourceManager resourceManager) throws BadRequestException {
+
         return getBulkResponseContent(bulkRequestContent, null, resourceManager);
     }
 
-   private BulkResponseContent getBulkResponseContent
-           (BulkRequestContent bulkRequestContent, Map<String, String> userIdMappings,
-            ResourceManager resourceManager)
+   private BulkResponseContent getBulkResponseContent(BulkRequestContent bulkRequestContent,
+                                                      Map<String, String> userIdMappings,
+                                                      ResourceManager resourceManager)
            throws BadRequestException {
 
        BulkResponseContent bulkResponseContent = null;
        SCIMResponse response;
-
        processBulkRequestContent(bulkRequestContent, userIdMappings, bulkRequestContent.getMethod());
 
        switch (bulkRequestContent.getMethod()) {
@@ -194,24 +193,23 @@ public class BulkRequestProcessor {
                            null, null);
                }
 
-               bulkResponseContent = createBulkResponseContent
-                       (response, SCIMConstants.OperationalConstants.POST, bulkRequestContent);
+               bulkResponseContent = createBulkResponseContent(response, SCIMConstants.OperationalConstants.POST,
+                       bulkRequestContent);
                errorsCheck(response);
                break;
 
            case SCIMConstants.OperationalConstants.PUT: {
                String resourceId = extractIDFromPath(bulkRequestContent.getPath());
                if (bulkRequestContent.getPath().contains(SCIMConstants.ROLE_ENDPOINT)) {
-                   response = resourceManager.updateWithPUTRole(resourceId,
-                           bulkRequestContent.getData(), roleManager);
+                   response = resourceManager.updateWithPUTRole(resourceId, bulkRequestContent.getData(),
+                           roleManager);
                } else {
-                   response = resourceManager
-                           .updateWithPUT(resourceId, bulkRequestContent.getData(), userManager,
+                   response = resourceManager.updateWithPUT(resourceId, bulkRequestContent.getData(), userManager,
                                    null, null);
                }
 
-               bulkResponseContent = createBulkResponseContent
-                       (response, SCIMConstants.OperationalConstants.PUT, bulkRequestContent);
+               bulkResponseContent = createBulkResponseContent(response, SCIMConstants.OperationalConstants.PUT,
+                       bulkRequestContent);
                errorsCheck(response);
                break;
            }
@@ -219,16 +217,15 @@ public class BulkRequestProcessor {
            case SCIMConstants.OperationalConstants.PATCH: {
                String resourceId = extractIDFromPath(bulkRequestContent.getPath());
                if (bulkRequestContent.getPath().contains(SCIMConstants.ROLE_ENDPOINT)) {
-                   response = resourceManager.updateWithPATCHRole(resourceId,
-                           bulkRequestContent.getData(), roleManager);
+                   response = resourceManager.updateWithPATCHRole(resourceId, bulkRequestContent.getData(),
+                           roleManager);
                } else {
-                   response = resourceManager
-                           .updateWithPATCH(resourceId, bulkRequestContent.getData(), userManager,
+                   response = resourceManager.updateWithPATCH(resourceId, bulkRequestContent.getData(), userManager,
                                    null, null);
                }
 
-               bulkResponseContent = createBulkResponseContent
-                       (response, SCIMConstants.OperationalConstants.PATCH, bulkRequestContent);
+               bulkResponseContent = createBulkResponseContent(response, SCIMConstants.OperationalConstants.PATCH,
+                       bulkRequestContent);
                errorsCheck(response);
                break;
            }
@@ -241,8 +238,8 @@ public class BulkRequestProcessor {
                    response = resourceManager.delete(resourceId, userManager);
                }
 
-               bulkResponseContent = createBulkResponseContent
-                       (response, SCIMConstants.OperationalConstants.DELETE, bulkRequestContent);
+               bulkResponseContent = createBulkResponseContent(response, SCIMConstants.OperationalConstants.DELETE,
+                       bulkRequestContent);
                errorsCheck(response);
                break;
            }
@@ -251,6 +248,7 @@ public class BulkRequestProcessor {
    }
 
     private String extractIDFromPath(String path) throws BadRequestException {
+
         String [] parts = path.split("[/]");
         if (parts[2] != null) {
             return parts[2];
@@ -262,8 +260,8 @@ public class BulkRequestProcessor {
 
     private BulkResponseContent createBulkResponseContent(SCIMResponse response, String method,
                                                           BulkRequestContent requestContent) {
-        BulkResponseContent bulkResponseContent = new BulkResponseContent();
 
+        BulkResponseContent bulkResponseContent = new BulkResponseContent();
         bulkResponseContent.setScimResponse(response);
         bulkResponseContent.setMethod(method);
         if (response.getHeaderParamMap() != null) {
@@ -273,7 +271,6 @@ public class BulkRequestProcessor {
         bulkResponseContent.setVersion(requestContent.getVersion());
 
         return bulkResponseContent;
-
     }
 
     private void errorsCheck(SCIMResponse response) {
@@ -287,17 +284,16 @@ public class BulkRequestProcessor {
      * This method is used to process the bulk request content.
      * This method will replace the bulk id with the created user id.
      *
-     * @param bulkRequestContent Bulk request content
-     * @param userIDMappings User id bulk id mapping
-     * @param method HTTP method
-     * @throws BadRequestException Bad request exception
+     * @param bulkRequestContent   Bulk request content.
+     * @param userIDMappings       User id bulk id mapping.
+     * @param method               HTTP method.
+     * @throws BadRequestException Bad request exception.
      */
-    private void processBulkRequestContent(BulkRequestContent bulkRequestContent,
-                                           Map<String, String> userIDMappings, String method)
-            throws BadRequestException {
+    private void processBulkRequestContent(BulkRequestContent bulkRequestContent, Map<String, String> userIDMappings,
+                                           String method) throws BadRequestException {
+
         try {
-            if (userIDMappings == null
-                    || userIDMappings.isEmpty()
+            if (userIDMappings == null || userIDMappings.isEmpty()
                     || method.equals(SCIMConstants.OperationalConstants.DELETE)) {
                 return;
             }
@@ -308,7 +304,6 @@ public class BulkRequestProcessor {
 
             if (usersArray != null) {
                 String bulkIdPrefix = SCIMConstants.OperationalConstants.BULK_ID + ":";
-
                 for (int i = 0; i < usersArray.length(); i++) {
                     JSONObject user = usersArray.getJSONObject(i);
                     String userValue = user.getString(SCIMConstants.OperationalConstants.VALUE);
@@ -330,21 +325,23 @@ public class BulkRequestProcessor {
     }
 
     private String getUsersOrMembersKey(String path) {
+
         return path.contains(SCIMConstants.ROLE_ENDPOINT) ? SCIMConstants.RoleSchemaConstants.USERS :
                 SCIMConstants.GroupSchemaConstants.MEMBERS;
     }
 
     /**
      * This method is used to get the user array from the data JSON object.
-     * @param dataJson SCIM data JSON object
-     * @param method HTTP method
+     * @param dataJson          SCIM data JSON object
+     * @param method            HTTP method
      * @param usersOrMembersKey Users or members key
      *
      * @return User array
-     * @throws JSONException JSON exception
+     * @throws JSONException    JSON exception
      */
     private JSONArray getUserArray(JSONObject dataJson, String method, String usersOrMembersKey)
             throws JSONException {
+
         switch (method) {
             case SCIMConstants.OperationalConstants.POST:
             case SCIMConstants.OperationalConstants.PUT:
@@ -357,8 +354,8 @@ public class BulkRequestProcessor {
     }
 
     private JSONArray getUserArrayForPatch(JSONObject dataJson, String usersOrMembersKey) throws JSONException {
-        JSONArray operations = dataJson.optJSONArray(SCIMConstants.OperationalConstants.OPERATIONS);
 
+        JSONArray operations = dataJson.optJSONArray(SCIMConstants.OperationalConstants.OPERATIONS);
         if (operations != null) {
             for (int i = 0; i < operations.length(); i++) {
                 JSONObject operation = operations.getJSONObject(i);
@@ -378,6 +375,7 @@ public class BulkRequestProcessor {
     }
 
     private boolean isAddOperation(JSONObject operation, String path) throws JSONException {
+
         String operationType = operation.optString(SCIMConstants.OperationalConstants.OP);
         String operationPath = operation.optString(SCIMConstants.OperationalConstants.PATH, "");
 
@@ -387,13 +385,13 @@ public class BulkRequestProcessor {
 
     /**
      * This method is used to get user id bulk id mapping from the bulk user operation response.
-     * @param bulkUserOperationResponse Bulk user operation response
+     * @param bulkUserOperationResponse Bulk user operation response.
      *
-     * @return Bulk id user id mapping
+     * @return Bulk id user id mapping.
      */
     private static Map<String, String> getUserIdBulkIdMapping(List<BulkResponseContent> bulkUserOperationResponse) {
-        Map<String, String> userIdMappings = new HashMap<>();
 
+        Map<String, String> userIdMappings = new HashMap<>();
         for (BulkResponseContent bulkResponse : bulkUserOperationResponse) {
             String bulkId = bulkResponse.getBulkID();
 

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/BulkRequestProcessor.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/BulkRequestProcessor.java
@@ -318,7 +318,6 @@ public class BulkRequestProcessor {
                 }
             }
             bulkRequestContent.setData(dataJson.toString());
-
         } catch (JSONException e) {
             throw new BadRequestException("Error while parsing the data field of the bulk request content",
                     ResponseCodeConstants.INVALID_SYNTAX);

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMConstants.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMConstants.java
@@ -775,6 +775,8 @@ public class SCIMConstants {
         public static final String PUT = "PUT";
         public static final String PATCH = "PATCH";
 
+        public static final String COLON = ":";
+        public static final String URL_SEPARATOR = "/";
 
     }
 }


### PR DESCRIPTION
Related Issue - https://github.com/wso2/product-is/issues/3300

Per the SCIM2 specification, a client can perform multiple actions within a single bulk operation, such as creating a new user, forming a new group, and subsequently adding the recently created user to this group. To achieve this, the client must utilize the surrogate ID attribute, bulkId, to reference the user. Our system currently lacks support for this functionality. This implementation introduces support for the aforementioned feature.

