### PR TITLE
Fix patch /Groups when path parameter is present in the body

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
@@ -16,6 +16,7 @@
 package org.wso2.charon3.core.protocol.endpoints;
 
 import org.apache.commons.lang.StringUtils;
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -676,7 +677,8 @@ public class GroupResourceManager extends AbstractResourceManager {
         for (PatchOperation patchOperation : patchOperations) {
             String operation = patchOperation.getOperation();
             String path = patchOperation.getPath();
-            if (!(patchOperation.getValues() instanceof String)) {
+            if (!(SCIMConstants.OperationalConstants.ADD).equals(operation)
+                    && !(patchOperation.getValues() instanceof String)) {
                 JSONObject valuesJson = (JSONObject) patchOperation.getValues();
                 if (operation.equals(SCIMConstants.OperationalConstants.REPLACE) &&
                         ((path != null && path.equals(SCIMConstants.GroupSchemaConstants.MEMBERS)) ||
@@ -854,7 +856,7 @@ public class GroupResourceManager extends AbstractResourceManager {
                     patchOperation.setValues(attributePrefixedJson);
                 } else if (patchOperation.getPath().equals(SCIMConstants.GroupSchemaConstants.MEMBERS) &&
                         patchOperation.getValues() != null) {
-                    JSONObject valuesPropertyJson = (JSONObject) patchOperation.getValues();
+                    JSONArray valuesPropertyJson = (JSONArray) patchOperation.getValues();
                     JSONObject attributePrefixedJson = new JSONObject();
 
                     attributePrefixedJson.put(SCIMConstants.GroupSchemaConstants.MEMBERS, valuesPropertyJson);


### PR DESCRIPTION
### Purpose

This issue fixes https://github.com/wso2/product-is/issues/16933

In the PATCH `/Groups` request when the path attribute is set as `members`, the value should be in the form of an array. However in the existing implementation, the `value` attribute in the request body is casted to JSONObject which causes a runtime exception. This PR changes the type of casting to JSONArray.

As per the documentation [1], the `value` attribute should be an array.
<img width="894" alt="Screenshot 2024-01-03 at 15 53 08" src="https://github.com/wso2-support/charon/assets/28347418/d40fac20-6d26-4134-92ea-1e4829e9e6e4">

[1] https://is.docs.wso2.com/en/latest/apis/scim2-rest-apis/#/Groups%20Endpoint/patchGroup
