### PR TITLE
Enforce maximum operation count for scim2/Bulk API

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/ResponseCodeConstants.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/ResponseCodeConstants.java
@@ -74,6 +74,8 @@ public class ResponseCodeConstants {
 
     public static final int CODE_PAYLOAD_TOO_LARGE = 413;
     public static final String DESC_PAYLOAD_TOO_LARGE = "{\"maxOperations\": 1000,\"maxPayloadSize\": 1048576}";
+    public static final String ERROR_DESC_MAX_OPERATIONS_EXCEEDED = "Bulk operation count exceeds the maximum " +
+            "allowed limit.";
 
     public static final int CODE_INTERNAL_ERROR = 500;
     public static final String DESC_INTERNAL_ERROR = "An internal error.";

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/ResponseCodeConstants.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/ResponseCodeConstants.java
@@ -74,8 +74,8 @@ public class ResponseCodeConstants {
 
     public static final int CODE_PAYLOAD_TOO_LARGE = 413;
     public static final String DESC_PAYLOAD_TOO_LARGE = "{\"maxOperations\": 1000,\"maxPayloadSize\": 1048576}";
-    public static final String ERROR_DESC_MAX_OPERATIONS_EXCEEDED = "Bulk operation count exceeds the maximum " +
-            "allowed limit.";
+    public static final String ERROR_DESC_MAX_OPERATIONS_EXCEEDED = "The number of operations in the bulk " +
+            "request: %d exceeds the maximum total number of operations count: %d.";
 
     public static final int CODE_INTERNAL_ERROR = 500;
     public static final String DESC_INTERNAL_ERROR = "An internal error.";

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/BulkResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/BulkResourceManager.java
@@ -17,11 +17,14 @@ package org.wso2.charon3.core.protocol.endpoints;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.charon3.core.config.CharonConfiguration;
+import org.wso2.charon3.core.config.SCIMConfigConstants;
 import org.wso2.charon3.core.encoder.JSONDecoder;
 import org.wso2.charon3.core.encoder.JSONEncoder;
 import org.wso2.charon3.core.exceptions.BadRequestException;
 import org.wso2.charon3.core.exceptions.CharonException;
 import org.wso2.charon3.core.exceptions.InternalErrorException;
+import org.wso2.charon3.core.exceptions.PayloadTooLargeException;
 import org.wso2.charon3.core.extensions.RoleManager;
 import org.wso2.charon3.core.extensions.RoleV2Manager;
 import org.wso2.charon3.core.extensions.UserManager;
@@ -80,6 +83,19 @@ public class BulkResourceManager extends AbstractResourceManager {
             bulkRequestProcessor.setFailOnError(bulkRequestDataObject.getFailOnErrors());
             bulkRequestProcessor.setUserManager(userManager);
 
+            int maxOperationCount =
+                    (Integer) CharonConfiguration.getInstance().getConfig().get(SCIMConfigConstants.MAX_OPERATIONS);
+            int totalOperationCount = bulkRequestDataObject.getUserOperationRequests().size() +
+                    bulkRequestDataObject.getGroupOperationRequests().size() +
+                    bulkRequestDataObject.getRoleOperationRequests().size() +
+                    bulkRequestDataObject.getRoleV2OperationRequests().size();
+            if (totalOperationCount > maxOperationCount) {
+                throw new PayloadTooLargeException(String.format("%s Actual: %d, Max allowed: %d.",
+                        ResponseCodeConstants.ERROR_DESC_MAX_OPERATIONS_EXCEEDED,
+                        totalOperationCount,
+                        maxOperationCount));
+            }
+
             // Get bulk response data.
             bulkResponseData = bulkRequestProcessor.processBulkRequests(bulkRequestDataObject);
             //encode the BulkResponseData object
@@ -93,7 +109,7 @@ public class BulkResourceManager extends AbstractResourceManager {
             // Create the final response.
             return new SCIMResponse(ResponseCodeConstants.CODE_OK, finalEncodedResponse, responseHeaders);
 
-        } catch (CharonException | BadRequestException | InternalErrorException e) {
+        } catch (CharonException | BadRequestException | InternalErrorException | PayloadTooLargeException e) {
             return AbstractResourceManager.encodeSCIMException(e);
         }
     }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/BulkResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/BulkResourceManager.java
@@ -90,10 +90,10 @@ public class BulkResourceManager extends AbstractResourceManager {
                     bulkRequestDataObject.getRoleOperationRequests().size() +
                     bulkRequestDataObject.getRoleV2OperationRequests().size();
             if (totalOperationCount > maxOperationCount) {
-                throw new PayloadTooLargeException(String.format("%s Actual: %d, Max allowed: %d.",
-                        ResponseCodeConstants.ERROR_DESC_MAX_OPERATIONS_EXCEEDED,
-                        totalOperationCount,
-                        maxOperationCount));
+                throw new PayloadTooLargeException(
+                        String.format(ResponseCodeConstants.ERROR_DESC_MAX_OPERATIONS_EXCEEDED,
+                                totalOperationCount,
+                                maxOperationCount));
             }
 
             // Get bulk response data.

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/BulkResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/BulkResourceManager.java
@@ -90,6 +90,11 @@ public class BulkResourceManager extends AbstractResourceManager {
                     bulkRequestDataObject.getRoleOperationRequests().size() +
                     bulkRequestDataObject.getRoleV2OperationRequests().size();
             if (totalOperationCount > maxOperationCount) {
+                if (logger.isDebugEnabled()) {
+                    logger.debug(String.format(ResponseCodeConstants.ERROR_DESC_MAX_OPERATIONS_EXCEEDED,
+                            totalOperationCount,
+                            maxOperationCount));
+                }
                 throw new PayloadTooLargeException(
                         String.format(ResponseCodeConstants.ERROR_DESC_MAX_OPERATIONS_EXCEEDED,
                                 totalOperationCount,


### PR DESCRIPTION
## Purpose
This PR enforces maximum operation count for scim2/Bulk API.
Default maximum operation count is 1000. 
This maximum operation count can be changed by adding following config to `deployment.toml`.

```
[scim2]
max_bulk_operations=500
```

Sample Response:
<img width="911" alt="image" src="https://github.com/wso2/charon/assets/61885844/3a2903d4-1289-40d3-929d-81a89a5db02c">

## Related Issues
- https://github.com/wso2/product-is/issues/19541