### PR TITLE
Add ClassCastException for request body json decoding

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONDecoder.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONDecoder.java
@@ -775,7 +775,7 @@ public class JSONDecoder {
                 patchOperation.setValues(operation.opt(SCIMConstants.OperationalConstants.VALUE));
                 operationList.add(patchOperation);
             }
-        } catch (JSONException e) {
+        } catch (JSONException | ClassCastException e) {
             if (logger.isDebugEnabled()) {
                 logger.debug("json error in decoding the request", e);
             }


### PR DESCRIPTION
### Description
Handling ClassCastException at request body is required since there can be instances where the request is malformed with double array objects. It should be treated as 400 Bad Request.