### PR TITLE
Fix: Swap Role Error Response and SCIM Type

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/exceptions/BadRequestException.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/exceptions/BadRequestException.java
@@ -28,7 +28,7 @@ public class BadRequestException extends AbstractCharonException {
     }
 
     public BadRequestException(String scimType) {
-        this(ResponseCodeConstants.DESC_BAD_REQUEST, scimType);
+        this(scimType, ResponseCodeConstants.DESC_BAD_REQUEST);
     }
 
     public BadRequestException(String details, String scimType) {


### PR DESCRIPTION
## Purpose
> Resolves the issue [#19746](https://github.com/wso2/product-is/issues/19746) where the error message for role creation is not properly displayed when the role name starts with "system_". 

## Goals
> Provide clear and accurate error messages when attempting to create roles that are not permitted.

## Approach
> The error detail was incorrectly placed in the scimType attribute, causing confusion and improper error reporting in the console. The solution involved swapping the scimType and error detail variables.

## Samples
> <img width="994" alt="Screenshot 2024-06-26 at 10 45 20 AM" src="https://github.com/wso2/charon/assets/86454991/767209c9-50ab-4641-8310-1ed735f6a843">

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes