### PR TITLE
Fix the null pointer for operation json list.

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONDecoder.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONDecoder.java
@@ -753,6 +753,18 @@ public class JSONDecoder {
             JSONObject decodedJsonObj = new JSONObject(new JSONTokener(scimResourceString));
             //obtain the Operations values
             JSONArray operationJsonList = (JSONArray) decodedJsonObj.opt(SCIMConstants.OperationalConstants.OPERATIONS);
+
+            //check if operationJsonList is null
+            if (operationJsonList == null) {
+
+                //check if operations field present in lowercase
+                if (decodedJsonObj.has(StringUtils.lowerCase(SCIMConstants.OperationalConstants.OPERATIONS))) {
+                    throw new BadRequestException("Invalid JSON schema.", ResponseCodeConstants.INVALID_SYNTAX);
+                }
+
+                throw new BadRequestException(ResponseCodeConstants.INVALID_SYNTAX);
+            }
+
             //for each operation, create a PatchOperation object and add the relevant values to it
             for (int count = 0; count < operationJsonList.length(); count++) {
                 JSONObject operation = (JSONObject) operationJsonList.get(count);

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONDecoder.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONDecoder.java
@@ -756,12 +756,10 @@ public class JSONDecoder {
 
             //check if operationJsonList is null
             if (operationJsonList == null) {
-
                 //check if operations field present in lowercase
                 if (decodedJsonObj.has(StringUtils.lowerCase(SCIMConstants.OperationalConstants.OPERATIONS))) {
                     throw new BadRequestException("Invalid JSON schema.", ResponseCodeConstants.INVALID_SYNTAX);
                 }
-
                 throw new BadRequestException(ResponseCodeConstants.INVALID_SYNTAX);
             }
 

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONDecoder.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONDecoder.java
@@ -754,9 +754,9 @@ public class JSONDecoder {
             //obtain the Operations values
             JSONArray operationJsonList = (JSONArray) decodedJsonObj.opt(SCIMConstants.OperationalConstants.OPERATIONS);
 
-            //check if operationJsonList is null
+            // Check if operationJsonList is null.
             if (operationJsonList == null) {
-                //check if operations field present in lowercase
+                // Check if operations field present in lowercase.
                 if (decodedJsonObj.has(StringUtils.lowerCase(SCIMConstants.OperationalConstants.OPERATIONS))) {
                     throw new BadRequestException("Invalid JSON schema.", ResponseCodeConstants.INVALID_SYNTAX);
                 }


### PR DESCRIPTION
## Purpose
Fix https://github.com/wso2/product-is/issues/19409

This issue occures, when a invalid operation schema field given since it only accepts `Operations` field. Once json schema not contains this fieed correctly it will create a null pointer and raise an error in a for loop used to iterate that operation list.

## Goals
Handle the internal error in PATCH `scim2/v2/roles/{id}` API. 

## Approach
- Check weather operation list is null first.
- If yes, then it checks json schema contains `operations` field and throws an bad request error with invalid json schema.
- If operation list is null and still not has `operations` throws an bad request error with default error description.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
<img width="671" alt="image" src="https://github.com/wso2/charon/assets/79596630/a805d871-35cc-4537-9456-33da795b2795">


## Related PRs
https://github.com/wso2/docs-is/pull/4395