### PR TITLE
Introduce additional attribute json properties option

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/attributes/AbstractAttribute.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/attributes/AbstractAttribute.java
@@ -153,17 +153,17 @@ public abstract class AbstractAttribute implements Attribute {
         return additionalAttributeJSONProperties;
     }
 
-    public JSONObject getAttributeJsonProperty(String propertyName) {
+    public JSONObject getAttributeJSONProperty(String propertyName) {
 
         return additionalAttributeJSONProperties.get(propertyName);
     }
 
-    public void addAttributeJsonProperty(String propertyName, JSONObject jsonObject) {
+    public void addAttributeJSONProperty(String propertyName, JSONObject jsonObject) {
 
         this.additionalAttributeJSONProperties.put(propertyName, jsonObject);
     }
 
-    public JSONObject removeAttributeJsonProperty(String propertyName) {
+    public JSONObject removeAttributeJSONProperty(String propertyName) {
 
         return additionalAttributeJSONProperties.remove(propertyName);
     }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/attributes/AbstractAttribute.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/attributes/AbstractAttribute.java
@@ -153,12 +153,17 @@ public abstract class AbstractAttribute implements Attribute {
         return additionalAttributeJSONProperties;
     }
 
+    public JSONObject getAttributeJsonProperty(String propertyName) {
+
+        return additionalAttributeJSONProperties.get(propertyName);
+    }
+
     public void addAttributeJsonProperty(String propertyName, JSONObject jsonObject) {
 
         this.additionalAttributeJSONProperties.put(propertyName, jsonObject);
     }
 
-    public JSONObject getAttributeJsonProperty(String propertyName) {
+    public JSONObject removeAttributeJsonProperty(String propertyName) {
 
         return additionalAttributeJSONProperties.remove(propertyName);
     }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/attributes/AbstractAttribute.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/attributes/AbstractAttribute.java
@@ -15,6 +15,7 @@
  */
 package org.wso2.charon3.core.attributes;
 
+import org.json.JSONObject;
 import org.wso2.charon3.core.schema.SCIMDefinitions;
 
 import java.util.HashMap;
@@ -48,6 +49,7 @@ public abstract class AbstractAttribute implements Attribute {
     protected SCIMDefinitions.Uniqueness uniqueness;
     //A container to hold custom attribute properties.
     protected Map<String, String> additionalAttributeProperties = new HashMap<>();
+    protected Map<String, JSONObject> additionalAttributeJSONProperties = new HashMap<>();
 
     public String getURI() {
         return uri; }
@@ -144,5 +146,20 @@ public abstract class AbstractAttribute implements Attribute {
     public String removeAttributeProperty(String propertyName) {
 
         return additionalAttributeProperties.remove(propertyName);
+    }
+
+    public Map<String, JSONObject> getAttributeJSONProperties() {
+
+        return additionalAttributeJSONProperties;
+    }
+
+    public void addAttributeJsonProperty(String propertyName, JSONObject jsonObject) {
+
+        this.additionalAttributeJSONProperties.put(propertyName, jsonObject);
+    }
+
+    public JSONObject getAttributeJsonProperty(String propertyName) {
+
+        return additionalAttributeJSONProperties.remove(propertyName);
     }
 }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/attributes/Attribute.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/attributes/Attribute.java
@@ -15,6 +15,7 @@
  */
 package org.wso2.charon3.core.attributes;
 
+import org.json.JSONObject;
 import org.wso2.charon3.core.exceptions.CharonException;
 import org.wso2.charon3.core.schema.SCIMDefinitions;
 
@@ -59,6 +60,11 @@ public interface Attribute extends Serializable {
     }
 
     public default Map<String, String> getAttributeProperties() {
+
+        throw new UnsupportedOperationException();
+    }
+
+    public default Map<String, JSONObject> getAttributeJSONProperties() {
 
         throw new UnsupportedOperationException();
     }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/attributes/Attribute.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/attributes/Attribute.java
@@ -68,4 +68,9 @@ public interface Attribute extends Serializable {
 
         throw new UnsupportedOperationException();
     }
+
+    public default JSONObject getAttributeJSONProperty(String propertyName) {
+
+        throw new UnsupportedOperationException();
+    }
 }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONEncoder.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONEncoder.java
@@ -233,6 +233,11 @@ public class JSONEncoder {
             attributeSchema.put(entry.getKey(), entry.getValue());
         }
 
+        Map<String, JSONObject> customJSONProperties = attribute.getAttributeJSONProperties();
+        for (Map.Entry<String, JSONObject> entry: customJSONProperties.entrySet()) {
+            attributeSchema.put(entry.getKey(), entry.getValue());
+        }
+
         return attributeSchema;
     }
 

--- a/modules/charon-core/src/test/java/org/wso2/charon3/core/encoder/JsonEncoderTest.java
+++ b/modules/charon-core/src/test/java/org/wso2/charon3/core/encoder/JsonEncoderTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.charon3.core.encoder;
+
+import org.json.JSONObject;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.charon3.core.attributes.AbstractAttribute;
+import org.wso2.charon3.core.attributes.SimpleAttribute;
+import org.wso2.charon3.core.schema.SCIMDefinitions;
+
+/**
+ * Test class for JSONEncoder.
+ */
+public class JsonEncoderTest {
+
+    private JSONEncoder jsonEncoder;
+
+    @BeforeMethod
+    public void setUp() {
+
+        jsonEncoder = new JSONEncoder();
+    }
+
+    @Test
+    public void testEncodeBasicAttributeSchema() {
+
+        AbstractAttribute attribute = new SimpleAttribute("test", null);
+        attribute.setType(SCIMDefinitions.DataType.STRING);
+        attribute.setMultiValued(false);
+        attribute.setDescription("Test Description");
+        attribute.setRequired(true);
+        attribute.setCaseExact(true);
+        attribute.setReturned(SCIMDefinitions.Returned.DEFAULT);
+        attribute.setMutability(SCIMDefinitions.Mutability.READ_WRITE);
+        attribute.setURI("testURI");
+        attribute.setUniqueness(SCIMDefinitions.Uniqueness.NONE);
+        attribute.addAttributeProperty("custom1", "value1");
+
+        JSONObject testJsonObject = new JSONObject();
+        testJsonObject.put("key1", "value1");
+        attribute.addAttributeJsonProperty("json1", testJsonObject);
+        attribute.addAttributeJsonProperty("json2", new JSONObject());
+        attribute.removeAttributeJsonProperty("json2");
+
+        JSONObject responseJson = jsonEncoder.encodeBasicAttributeSchema(attribute);
+
+        // Assert.
+        Assert.assertEquals(responseJson.get("name"), "test");
+        Assert.assertEquals(responseJson.get("type"), SCIMDefinitions.DataType.STRING);
+        Assert.assertEquals(responseJson.get("multiValued"), false);
+        Assert.assertEquals(responseJson.get("description"), "Test Description");
+        Assert.assertEquals(responseJson.get("required"), true);
+        Assert.assertEquals(responseJson.get("caseExact"), true);
+        Assert.assertEquals(responseJson.get("mutability"), SCIMDefinitions.Mutability.READ_WRITE);
+        Assert.assertEquals(responseJson.get("returned"), SCIMDefinitions.Returned.DEFAULT);
+        Assert.assertEquals(responseJson.get("uniqueness"), SCIMDefinitions.Uniqueness.NONE);
+
+        Assert.assertEquals(responseJson.get("custom1"), "value1");
+
+        JSONObject customJson = responseJson.getJSONObject("json1");
+        Assert.assertEquals(customJson.get("key1"), "value1");
+
+        Assert.assertTrue(attribute.getAttributeJSONProperties().containsKey("json1"));
+        Assert.assertFalse(attribute.getAttributeJSONProperties().containsKey("json2"));
+        Assert.assertEquals(attribute.getAttributeJsonProperty("json1"), testJsonObject);
+    }
+}

--- a/modules/charon-core/src/test/java/org/wso2/charon3/core/encoder/JsonEncoderTest.java
+++ b/modules/charon-core/src/test/java/org/wso2/charon3/core/encoder/JsonEncoderTest.java
@@ -56,9 +56,9 @@ public class JsonEncoderTest {
 
         JSONObject testJsonObject = new JSONObject();
         testJsonObject.put("key1", "value1");
-        attribute.addAttributeJsonProperty("json1", testJsonObject);
-        attribute.addAttributeJsonProperty("json2", new JSONObject());
-        attribute.removeAttributeJsonProperty("json2");
+        attribute.addAttributeJSONProperty("json1", testJsonObject);
+        attribute.addAttributeJSONProperty("json2", new JSONObject());
+        attribute.removeAttributeJSONProperty("json2");
 
         JSONObject responseJson = jsonEncoder.encodeBasicAttributeSchema(attribute);
 
@@ -80,6 +80,6 @@ public class JsonEncoderTest {
 
         Assert.assertTrue(attribute.getAttributeJSONProperties().containsKey("json1"));
         Assert.assertFalse(attribute.getAttributeJSONProperties().containsKey("json2"));
-        Assert.assertEquals(attribute.getAttributeJsonProperty("json1"), testJsonObject);
+        Assert.assertEquals(attribute.getAttributeJSONProperty("json1"), testJsonObject);
     }
 }

--- a/modules/charon-core/src/test/resources/testng.xml
+++ b/modules/charon-core/src/test/resources/testng.xml
@@ -26,6 +26,7 @@
             <class name="org.wso2.charon3.core.utils.ResourceManagerUtilTest"/>
             <class name="org.wso2.charon3.core.utils.SchemaUtilTest"/>
             <class name="org.wso2.charon3.core.utils.PatchOperationUtilTest"/>
+            <class name="org.wso2.charon3.core.encoder.JsonEncoderTest"/>
             <class name="org.wso2.charon3.core.schema.ServerSideValidatorTest"/>
             <class name="org.wso2.charon3.core.protocol.endpoints.UserResourceManagerTest"/>
             <class name="org.wso2.charon3.core.protocol.endpoints.MeResourceManagerTest"/>


### PR DESCRIPTION
## Purpose
The current implementation of the scim2/Schemas response supports only string-based additional properties. To enhance flexibility and allow the inclusion of more complex data structures, this update introduces the ability to add JSON objects as first-class properties to the Schemas endpoint. This is particularly useful for returning properties such as attribute profiles, which require a structured JSON format.

<img width="359" alt="image" src="https://github.com/user-attachments/assets/12125146-1d74-4cbc-b66c-f59cb6a497b5" />


### Related Issues
- https://github.com/wso2/product-is/issues/22163