### PR TITLE
Skip the validation for integer type with empty values.

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/attributes/DefaultAttributeFactory.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/attributes/DefaultAttributeFactory.java
@@ -1,20 +1,23 @@
 /*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2016-2025,  WSO2 LLC. (http://www.wso2.com).
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
  * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.wso2.charon3.core.attributes;
 
+import org.apache.commons.lang.StringUtils;
 import org.wso2.charon3.core.exceptions.BadRequestException;
 import org.wso2.charon3.core.exceptions.CharonException;
 import org.wso2.charon3.core.protocol.ResponseCodeConstants;
@@ -109,6 +112,10 @@ public class DefaultAttributeFactory {
             case DECIMAL:
                 return attributeValue instanceof Double;
             case INTEGER:
+                // Skipping the empty string check for integer attributes since this is the value clear use case.
+                if (StringUtils.isEmpty(attributeValue.toString())) {
+                    return true;
+                }
                 return attributeValue instanceof Integer;
             case DATE_TIME:
                 return attributeValue instanceof Instant;

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/AttributeUtil.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/AttributeUtil.java
@@ -1,17 +1,19 @@
 /*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2016-2025,  WSO2 LLC. (http://www.wso2.com).
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
  * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.wso2.charon3.core.utils;
 
@@ -73,6 +75,10 @@ public class AttributeUtil {
             case DECIMAL:
                 return Double.parseDouble(attributeStringValue);
             case INTEGER:
+                // Return value as it is since the value is an empty string.
+                if (StringUtils.isEmpty(attributeStringValue)) {
+                    return attributeValue;
+                }
                 return Integer.parseInt(attributeStringValue);
             case DATE_TIME:
                 return parseDateTime(attributeStringValue);

--- a/modules/charon-core/src/test/java/org/wso2/charon3/core/attributes/DefaultAttributeFactoryTest.java
+++ b/modules/charon-core/src/test/java/org/wso2/charon3/core/attributes/DefaultAttributeFactoryTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2025,  WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.charon3.core.attributes;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.charon3.core.exceptions.BadRequestException;
+import org.wso2.charon3.core.schema.SCIMDefinitions;
+
+import java.time.Instant;
+
+import static org.testng.Assert.assertEquals;
+import static org.wso2.charon3.core.schema.SCIMDefinitions.DataType.BOOLEAN;
+import static org.wso2.charon3.core.schema.SCIMDefinitions.DataType.DATE_TIME;
+import static org.wso2.charon3.core.schema.SCIMDefinitions.DataType.DECIMAL;
+import static org.wso2.charon3.core.schema.SCIMDefinitions.DataType.INTEGER;
+import static org.wso2.charon3.core.schema.SCIMDefinitions.DataType.STRING;
+
+public class DefaultAttributeFactoryTest {
+
+    @Test(dataProvider = "isAttributeDataTypeValidDataProvider")
+    public void testIsAttributeDataTypeValid(Object attribute, SCIMDefinitions.DataType dataType,
+                                             boolean expectedResult) throws BadRequestException {
+
+        boolean validationResult = DefaultAttributeFactory.isAttributeDataTypeValid(attribute, dataType);
+        assertEquals(validationResult, expectedResult, "Validation failed for attribute: " + attribute +
+                " and data type: " + dataType);
+    }
+
+    @DataProvider(name = "isAttributeDataTypeValidDataProvider")
+    public Object[][] isAttributeDataTypeValidDataProvider() {
+
+        return new Object[][]{
+                // Valid cases.
+                {"name", STRING, true},
+                {true, BOOLEAN, true},
+                {"", INTEGER, true},
+                {123, INTEGER, true},
+                {12.23, DECIMAL, true},
+                {Instant.now(), DATE_TIME, true},
+                {new Byte[]{1, 2, 3}, SCIMDefinitions.DataType.BINARY, true},
+                {"http://example.com", SCIMDefinitions.DataType.REFERENCE, true},
+                {"{\"name\":\"John\"}", SCIMDefinitions.DataType.COMPLEX, true},
+
+                // Invalid cases.
+                {123, STRING, false},
+                {"", BOOLEAN, false},
+                {true, INTEGER, false},
+                {"2023-01-01", DATE_TIME, false},
+                {10, DECIMAL, false},
+                {Instant.now(), SCIMDefinitions.DataType.BINARY, false},
+                {new Byte[]{1, 2, 3}, SCIMDefinitions.DataType.REFERENCE, false},
+                {123, SCIMDefinitions.DataType.COMPLEX, false}
+        };
+    }
+
+}

--- a/modules/charon-core/src/test/java/org/wso2/charon3/core/utils/AttributeUtilTest.java
+++ b/modules/charon-core/src/test/java/org/wso2/charon3/core/utils/AttributeUtilTest.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021-2025,  WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -65,7 +65,8 @@ public class AttributeUtilTest {
                 {"referenceString", REFERENCE, String.class},
                 {"complexString", COMPLEX, String.class},
                 {null, STRING, null},
-                {JSONObject.NULL, STRING, String.class}
+                {JSONObject.NULL, STRING, String.class},
+                {"", INTEGER, String.class}
         };
     }
 

--- a/modules/charon-core/src/test/resources/testng.xml
+++ b/modules/charon-core/src/test/resources/testng.xml
@@ -34,6 +34,7 @@
             <class name="org.wso2.charon3.core.config.SCIMSystemSchemaExtensionBuilderTest"/>
             <class name="org.wso2.charon3.core.schema.SCIMResourceSchemaManagerTest"/>
             <class name="org.wso2.charon3.core.config.encoder.JSONEncoderTest"/>
+            <class name="org.wso2.charon3.core.attributes.DefaultAttributeFactoryTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
### Purpose
- $subject

### Related issues
- https://github.com/wso2/product-is/issues/22281

### Approach
- With this PR, we are skipping the validations for integers when we recieve a empty string("") that means users can clear the integer value.
- At the moment if we receive a empty string then it will give 500 error when it tries to decode.
- With this fix, it will skip the value pass point and validation point for integer type when value equals to "".
- Note: When we set the value to "" in attribute this will not return to FE and therefore behaviour will not change as previous.