### PR TITLE
Fix user patch remove operation for migrating users

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMConstants.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/schema/SCIMConstants.java
@@ -863,6 +863,7 @@ public class SCIMConstants {
         public static final String COLON = ":";
         public static final String URL_SEPARATOR = "/";
         public static final String DOT_SEPARATOR = ".";
+        public static final String OPEN_SQUARE_BRACKET = "[";
 
     }
 }


### PR DESCRIPTION
### Purpose

1. When two remove operations are sent for the same local claim, there will be an error thrown for the second one as BadRequest because there is no attribute to remove. The attribute will be removed by the first operation itself. Therefore, we need to keep track of the attributes removed by the synced attributes and if the Bad Request is thrown because of such an attribute, ignore it.
```
{
    "op": "remove",
    "path": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:country"
},
{
    "op": "remove",
    "path": "urn:scim:wso2:schema:country"
},
```
2. Fix the path extraction for following type of requests.
```
{
    "op": "remove",
    "path": "urn:scim:wso2:schema:devices[value eq \"M7\"]"
},
``` 

### Related Issues
- https://github.com/wso2/product-is/issues/22610

### Related PRs
- https://github.com/wso2/charon/pull/422
- https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/600