### PR TITLE
Fix incorrect casting in SCIM2 Group Patch call

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
@@ -677,15 +677,18 @@ public class GroupResourceManager extends AbstractResourceManager {
         for (PatchOperation patchOperation : patchOperations) {
             String operation = patchOperation.getOperation();
             String path = patchOperation.getPath();
-            if (!(SCIMConstants.OperationalConstants.ADD).equals(operation)
-                    && !(patchOperation.getValues() instanceof String)) {
-                JSONObject valuesJson = (JSONObject) patchOperation.getValues();
-                if (operation.equals(SCIMConstants.OperationalConstants.REPLACE) &&
-                        ((path != null && path.equals(SCIMConstants.GroupSchemaConstants.MEMBERS)) ||
-                                (valuesJson != null && valuesJson.has(SCIMConstants.GroupSchemaConstants.MEMBERS)))) {
+
+            if (SCIMConstants.OperationalConstants.REMOVE.equals(operation) &&
+                    SCIMConstants.GroupSchemaConstants.MEMBERS.equals(path)) {
+                return true;
+            }
+
+            if (SCIMConstants.OperationalConstants.REPLACE.equals(operation)) {
+                if (SCIMConstants.GroupSchemaConstants.MEMBERS.equals(path)) {
                     return true;
-                } else if (operation.equals(SCIMConstants.OperationalConstants.REMOVE) && path != null
-                        && path.equals(SCIMConstants.GroupSchemaConstants.MEMBERS)) {
+                }
+                JSONObject valuesJson = (JSONObject) patchOperation.getValues();
+                if (valuesJson != null && valuesJson.has(SCIMConstants.GroupSchemaConstants.MEMBERS)) {
                     return true;
                 }
             }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManager.java
@@ -687,9 +687,12 @@ public class GroupResourceManager extends AbstractResourceManager {
                 if (SCIMConstants.GroupSchemaConstants.MEMBERS.equals(path)) {
                     return true;
                 }
-                JSONObject valuesJson = (JSONObject) patchOperation.getValues();
-                if (valuesJson != null && valuesJson.has(SCIMConstants.GroupSchemaConstants.MEMBERS)) {
-                    return true;
+                Object values = patchOperation.getValues();
+                if (values instanceof JSONObject) {
+                    JSONObject valuesJson = (JSONObject) patchOperation.getValues();
+                    if (valuesJson != null && valuesJson.has(SCIMConstants.GroupSchemaConstants.MEMBERS)) {
+                        return true;
+                    }
                 }
             }
         }

--- a/modules/charon-core/src/test/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManagerTest.java
+++ b/modules/charon-core/src/test/java/org/wso2/charon3/core/protocol/endpoints/GroupResourceManagerTest.java
@@ -954,32 +954,50 @@ public class GroupResourceManagerTest {
 
         List<PatchOperation> patchOperations;
         patchOperations = Collections.singletonList(
-                createPatchOperation(SCIMConstants.OperationalConstants.REMOVE, SCIMConstants.GroupSchemaConstants.MEMBERS, null)
+                createPatchOperation(SCIMConstants.OperationalConstants.REMOVE,
+                        SCIMConstants.GroupSchemaConstants.MEMBERS, null)
         );
-        assertTrue(invokeIsDeleteAllUsersOperationFound(patchOperations), "Should return true for remove members operation");
+        assertTrue(
+                invokeIsDeleteAllUsersOperationFound(patchOperations),
+                "Should return true for remove members operation"
+        );
 
         patchOperations = Collections.singletonList(
-                createPatchOperation(SCIMConstants.OperationalConstants.REPLACE, SCIMConstants.GroupSchemaConstants.MEMBERS, new JSONObject())
+                createPatchOperation(SCIMConstants.OperationalConstants.REPLACE,
+                        SCIMConstants.GroupSchemaConstants.MEMBERS, new JSONObject())
         );
-        assertTrue(invokeIsDeleteAllUsersOperationFound(patchOperations), "Should return true for replace members operation with path");
+        assertTrue(
+                invokeIsDeleteAllUsersOperationFound(patchOperations),
+                "Should return true for replace members operation with path"
+        );
 
         JSONObject values = new JSONObject();
         values.put(SCIMConstants.GroupSchemaConstants.MEMBERS, Collections.emptyList());
         patchOperations = Collections.singletonList(
                 createPatchOperation(SCIMConstants.OperationalConstants.REPLACE, "emails", values)
         );
-        assertTrue(invokeIsDeleteAllUsersOperationFound(patchOperations), "Should return true for replace operation with members in values");
+        assertTrue(
+                invokeIsDeleteAllUsersOperationFound(patchOperations),
+                "Should return true for replace operation with members in values"
+        );
 
         patchOperations = Arrays.asList(
-                createPatchOperation(SCIMConstants.OperationalConstants.ADD, SCIMConstants.GroupSchemaConstants.MEMBERS, new JSONObject()),
+                createPatchOperation(SCIMConstants.OperationalConstants.ADD,
+                        SCIMConstants.GroupSchemaConstants.MEMBERS, new JSONObject()),
                 createPatchOperation(SCIMConstants.OperationalConstants.REPLACE, "displayName", "New Group Name")
         );
-        assertFalse(invokeIsDeleteAllUsersOperationFound(patchOperations), "Should return false for no delete all users operation");
+        assertFalse(
+                invokeIsDeleteAllUsersOperationFound(patchOperations),
+                "Should return false for no delete all users operation"
+        );
 
         patchOperations = Collections.singletonList(
                 createPatchOperation(SCIMConstants.OperationalConstants.REPLACE, "displayName", "New Group Name")
         );
-        assertFalse(invokeIsDeleteAllUsersOperationFound(patchOperations), "Should return false for replace without members");
+        assertFalse(
+                invokeIsDeleteAllUsersOperationFound(patchOperations),
+                "Should return false for replace without members"
+        );
     }
 
     private PatchOperation createPatchOperation(String operation, String path, Object values) {


### PR DESCRIPTION
### Purpose

This PR addresses an incorrect casting issue within the `isDeleteAllUsersOperationFound` method in `GroupResourceManager.java`. The previous logic incorrectly assumed that the values of a PatchOperation would always be a JSONObject when the operation was not "add".

The changes in this PR ensure that the casting to JSONObject only occurs when the operation is "replace" and we are specifically checking for the presence of the "members" attribute. This prevents potential ClassCastException errors during SCIM2 group patch calls.

Additionally, the logic for identifying "delete all users" operations has been slightly re-organized for improved clarity and readability.

Currently, a group patch operation with following kind of payload fails because the value attribute is converted to a JSONObject when it is JSONArray.
```
{
  "schemas": [
    "urn:ietf:params:scim:api:messages:2.0:PatchOp"
  ],
  "operations": [
    {
      "op": "replace",
      "path": "members",
      "value": []
    }
  ]
}
```

### Related Issue
- https://github.com/wso2/product-is/issues/23957