### PR TITLE
Rename the newly introduced JsonArray support for the attributes

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/attributes/AbstractAttribute.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/attributes/AbstractAttribute.java
@@ -53,7 +53,7 @@ public abstract class AbstractAttribute implements Attribute {
     //A container to hold custom attribute properties.
     protected Map<String, String> additionalAttributeProperties = new HashMap<>();
     protected Map<String, JSONObject> additionalAttributeJSONProperties = new HashMap<>();
-    protected Map<String, JSONArray> additionalAttributeJSONPropertyArray = new HashMap<>();
+    protected Map<String, JSONArray> additionalAttributeJSONArrays = new HashMap<>();
 
     public String getURI() {
         return uri; }
@@ -172,23 +172,23 @@ public abstract class AbstractAttribute implements Attribute {
         return additionalAttributeJSONProperties.remove(propertyName);
     }
 
-    public Map<String, JSONArray> getAttributeJSONPropertyArrays() {
+    public Map<String, JSONArray> getAttributeJSONArrays() {
 
-        return additionalAttributeJSONPropertyArray;
+        return additionalAttributeJSONArrays;
     }
 
-    public JSONArray getAttributeJSONPropertyArray(String propertyName) {
+    public JSONArray getAttributeJSONArray(String propertyName) {
 
-        return additionalAttributeJSONPropertyArray.get(propertyName);
+        return additionalAttributeJSONArrays.get(propertyName);
     }
 
-    public void addAttributeJSONPropertyArray(String propertyName, JSONArray jsonArray) {
+    public void addAttributeJSONArray(String propertyName, JSONArray jsonArray) {
 
-        this.additionalAttributeJSONPropertyArray.put(propertyName, jsonArray);
+        this.additionalAttributeJSONArrays.put(propertyName, jsonArray);
     }
 
-    public JSONArray removeAttributeJSONPropertyArray(String propertyName) {
+    public JSONArray removeAttributeJSONArray(String propertyName) {
 
-        return additionalAttributeJSONPropertyArray.remove(propertyName);
+        return additionalAttributeJSONArrays.remove(propertyName);
     }
 }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/attributes/Attribute.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/attributes/Attribute.java
@@ -77,22 +77,22 @@ public interface Attribute extends Serializable {
         throw new UnsupportedOperationException();
     }
 
-    public default Map<String, JSONArray> getAttributeJSONPropertyArrays() {
+    public default Map<String, JSONArray> getAttributeJSONArrays() {
 
         throw new UnsupportedOperationException();
     }
 
-    public default JSONArray getAttributeJSONPropertyArray(String propertyName) {
+    public default JSONArray getAttributeJSONArray(String propertyName) {
 
         throw new UnsupportedOperationException();
     }
 
-    public default void addAttributeJSONPropertyArray(String propertyName, JSONArray jsonArray) {
+    public default void addAttributeJSONArray(String propertyName, JSONArray jsonArray) {
 
         throw new UnsupportedOperationException();
     }
 
-    public default JSONArray removeAttributeJSONPropertyArray(String propertyName) {
+    public default JSONArray removeAttributeJSONArray(String propertyName) {
 
         throw new UnsupportedOperationException();
     }

--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONEncoder.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONEncoder.java
@@ -240,7 +240,7 @@ public class JSONEncoder {
             attributeSchema.put(entry.getKey(), entry.getValue());
         }
 
-        Map<String, JSONArray> customJSONPropertyArrays = attribute.getAttributeJSONPropertyArrays();
+        Map<String, JSONArray> customJSONPropertyArrays = attribute.getAttributeJSONArrays();
         for (Map.Entry<String, JSONArray> entry: customJSONPropertyArrays.entrySet()) {
             attributeSchema.put(entry.getKey(), entry.getValue());
         }

--- a/modules/charon-core/src/test/java/org/wso2/charon3/core/encoder/JsonEncoderTest.java
+++ b/modules/charon-core/src/test/java/org/wso2/charon3/core/encoder/JsonEncoderTest.java
@@ -61,11 +61,11 @@ public class JsonEncoderTest {
         attribute.addAttributeJSONProperty("json2", new JSONObject());
         attribute.removeAttributeJSONProperty("json2");
 
-        JSONArray testJsonArray = new JSONArray("[{\"key\":\"A\",\"value\":\"a\"},{\"key\":\"B\"," +
-                "\"value\":\"b\"}]");
-        attribute.addAttributeJSONPropertyArray("jsonArray1", testJsonArray);
-        attribute.addAttributeJSONPropertyArray("jsonArray2", testJsonArray);
-        attribute.removeAttributeJSONPropertyArray("jsonArray2");
+        JSONArray testJsonArray = new JSONArray("[{\"value\":\"CA\",\"displayValue\":\"Current Account\"}," +
+                "{\"value\":\"FD\",\"displayValue\":\"Fixed Deposit\"}]");
+        attribute.addAttributeJSONArray("jsonArray1", testJsonArray);
+        attribute.addAttributeJSONArray("jsonArray2", testJsonArray);
+        attribute.removeAttributeJSONArray("jsonArray2");
 
         JSONObject responseJson = jsonEncoder.encodeBasicAttributeSchema(attribute);
 
@@ -89,8 +89,8 @@ public class JsonEncoderTest {
         Assert.assertFalse(attribute.getAttributeJSONProperties().containsKey("json2"));
         Assert.assertEquals(attribute.getAttributeJSONProperty("json1"), testJsonObject);
 
-        Assert.assertTrue(attribute.getAttributeJSONPropertyArrays().containsKey("jsonArray1"));
-        Assert.assertFalse(attribute.getAttributeJSONPropertyArrays().containsKey("jsonArray2"));
-        Assert.assertEquals(attribute.getAttributeJSONPropertyArray("jsonArray1"), testJsonArray);
+        Assert.assertTrue(attribute.getAttributeJSONArrays().containsKey("jsonArray1"));
+        Assert.assertFalse(attribute.getAttributeJSONArrays().containsKey("jsonArray2"));
+        Assert.assertEquals(attribute.getAttributeJSONArray("jsonArray1"), testJsonArray);
     }
 }


### PR DESCRIPTION
## Purpose

This PR improves naming clarity by renaming the following variable:

`additionalAttributeJSONPropertyArray → additionalAttributeJSONArrays`

Reason for change:

The original name was somewhat redundant and potentially misleading (mixing singular "Property" with plural "Array").

The new name aligns better with the existing naming convention:

- additionalAttributeProperties → Map<String, String>

- additionalAttributeJSONProperties → Map<String, JSONObject>

- ✅ additionalAttributeJSONArrays → Map<String, JSONArray>

This change enhances code readability and consistency, especially when dealing with different JSON data types.

### Related Issues
- https://github.com/wso2/product-is/issues/24049