### PR TITLE
Revert "Unify handling of unspecified count parameters for listWithGet and listWithPost"

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/ResourceManagerUtil.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/utils/ResourceManagerUtil.java
@@ -414,9 +414,9 @@ public class ResourceManagerUtil {
      */
     public static int processCount(String countStr) throws BadRequestException {
 
-        Integer count;
+        int count;
         if (countStr == null || countStr.trim().isEmpty() || !countStr.matches("\\d+")) {
-            count = null;
+            count = CharonConfiguration.getInstance().getCountValueForPagination();
         } else {
             try {
                 count = Integer.parseInt(countStr);
@@ -425,7 +425,11 @@ public class ResourceManagerUtil {
             }
         }
 
-        return processCount(count);
+        if (count < 0) {
+            count = 0;
+        }
+
+        return count;
     }
 
     /**
@@ -438,7 +442,7 @@ public class ResourceManagerUtil {
     public static Integer processCount(Integer countInt) {
 
         if (countInt == null || countInt.toString().isEmpty()) {
-            return CharonConfiguration.getInstance().getCountValueForPagination();
+            return null;
         } else {
             // All the negative values are interpreted as zero according to the specification.
             if (countInt <= 0) {

--- a/modules/charon-core/src/test/java/org/wso2/charon3/core/utils/ResourceManagerUtilTest.java
+++ b/modules/charon-core/src/test/java/org/wso2/charon3/core/utils/ResourceManagerUtilTest.java
@@ -236,7 +236,7 @@ public class ResourceManagerUtilTest {
 
                 {20, 20},
                 {-1, 0},
-                {null, 0}
+                {null, null}
         };
     }
 


### PR DESCRIPTION
Reverts wso2/charon#376

The proposed improvement should be further evaluated with considering the backward compatibility.

According to the previous behaviour, when limit is not set, the SCIM inbound implementation detect it as pagination not requested request and invoke the corresponding methods.  
But after this improvement, all the request will be treated as pagination requested requests (As the charon layer set the configured limit)

Also according to the previous behaviour, when the limit is not specified, the max user list defined in the user store managers are taken into consideration. But with this fix, that behaviour would be changed as we set a limit.