### PR TITLE
Validate 'schemas' attribute in JSONDecoder to ensure it is a valid JSON array

### DIFF
--- a/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONDecoder.java
+++ b/modules/charon-core/src/main/java/org/wso2/charon3/core/encoder/JSONDecoder.java
@@ -847,8 +847,14 @@ public class JSONDecoder {
                     decodedJsonObj.opt(SCIMConstants.OperationalConstants.ATTRIBUTES);
             JSONArray excludedAttributesValues = (JSONArray)
                     decodedJsonObj.opt(SCIMConstants.OperationalConstants.EXCLUDED_ATTRIBUTES);
-            JSONArray schemas = (JSONArray)
-                    decodedJsonObj.opt(SCIMConstants.CommonSchemaConstants.SCHEMAS);
+            JSONArray schemas = decodedJsonObj.optJSONArray(SCIMConstants.CommonSchemaConstants.SCHEMAS);
+
+            if (schemas == null) {
+                throw new BadRequestException(
+                    "Attribute 'schemas' is missing or is not a valid JSON array.", 
+                    ResponseCodeConstants.INVALID_VALUE
+                );
+            }
 
             if (schemas.length() != 1) {
                 throw new BadRequestException("Schema is invalid", ResponseCodeConstants.INVALID_VALUE);


### PR DESCRIPTION
## Purpose
- Resolves https://github.com/wso2/product-is/issues/25029
- This PR addresses both scenarios : ( will finally return 400 in response):
     - Receiving an invalid "schemas": {} in the payload, which causes a `ClassCastException`.
     - Omitting "schemas" in the payload, which causes a `NullPointerException`.

<img width="1073" height="667" alt="Screenshot 2025-08-11 at 09 48 31" src="https://github.com/user-attachments/assets/7658ed48-882e-4ec6-8c0e-d0ed013f4bec" />

<img width="1067" height="658" alt="Screenshot 2025-08-11 at 09 48 58" src="https://github.com/user-attachments/assets/0b3051fe-87e7-49f5-916a-3f8c64e5421d" />
